### PR TITLE
Add support for Block API's

### DIFF
--- a/Src/Notion.Client/Api/ApiEndpoints.cs
+++ b/Src/Notion.Client/Api/ApiEndpoints.cs
@@ -18,6 +18,7 @@
         public static class BlocksApiUrls
         {
             public static string RetrieveChildren(string blockId) => $"/v1/blocks/{blockId}/children";
+            public static string AppendChildren(string blockId) => $"/v1/blocks/{blockId}/children";
         }
     }
 }

--- a/Src/Notion.Client/Api/ApiEndpoints.cs
+++ b/Src/Notion.Client/Api/ApiEndpoints.cs
@@ -14,5 +14,10 @@
             public static string Retrieve(string userId) => $"/v1/users/{userId}";
             public static string List() => "/v1/users";
         }
+
+        public static class BlocksApiUrls
+        {
+            public static string RetrieveChildren(string blockId) => $"/v1/blocks/{blockId}/children";
+        }
     }
 }

--- a/Src/Notion.Client/Api/Blocks/BlocksAppendChildrenParameters.cs
+++ b/Src/Notion.Client/Api/Blocks/BlocksAppendChildrenParameters.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace Notion.Client
+{
+    // TODO: need an input version of Block
+    public interface IBlocksAppendChildrenBodyParameters
+    {
+        IEnumerable<BlockBase> Children { get; set; }
+    }
+
+    public class BlocksAppendChildrenParameters : IBlocksAppendChildrenBodyParameters
+    {
+        public IEnumerable<BlockBase> Children { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Blocks/BlocksClient.cs
+++ b/Src/Notion.Client/Api/Blocks/BlocksClient.cs
@@ -7,7 +7,7 @@ namespace Notion.Client
 {
     public interface IBlocksClient
     {
-        Task<PaginatedList<BlockBase>> RetrieveChildrenAsync(string blockId, BlockRetrieveChildrenParameters parameters = null);
+        Task<PaginatedList<BlockBase>> RetrieveChildrenAsync(string blockId, BlocksRetrieveChildrenParameters parameters = null);
         Task<BlockBase> AppendChildrenAsync(string blockId, BlocksAppendChildrenParameters parameters = null);
     }
 
@@ -20,7 +20,7 @@ namespace Notion.Client
             _client = client;
         }
 
-        public async Task<PaginatedList<BlockBase>> RetrieveChildrenAsync(string blockId, BlockRetrieveChildrenParameters parameters = null)
+        public async Task<PaginatedList<BlockBase>> RetrieveChildrenAsync(string blockId, BlocksRetrieveChildrenParameters parameters = null)
         {
             if (string.IsNullOrWhiteSpace(blockId))
             {
@@ -29,7 +29,7 @@ namespace Notion.Client
 
             var url = BlocksApiUrls.RetrieveChildren(blockId);
 
-            var queryParameters = (IBlockRetrieveChildrenQueryParameters)parameters;
+            var queryParameters = (IBlocksRetrieveChildrenQueryParameters)parameters;
 
             var queryParams = new Dictionary<string, string>()
             {
@@ -53,31 +53,5 @@ namespace Notion.Client
 
             return await _client.PatchAsync<BlockBase>(url, body);
         }
-    }
-
-    public interface IBlockRetrieveChildrenQueryParameters : IPaginationParameters
-    {
-    }
-
-    public interface IBlockRetrieveChildrenParameters : IBlockRetrieveChildrenQueryParameters
-    {
-    }
-
-    public class BlockRetrieveChildrenParameters : IBlockRetrieveChildrenParameters
-    {
-        public string StartCursor { get; set; }
-        public string PageSize { get; set; }
-    }
-
-
-    // TODO: need an input version of Block
-    public interface IBlocksAppendChildrenBodyParameters
-    {
-        IEnumerable<BlockBase> Children { get; set; }
-    }
-
-    public class BlocksAppendChildrenParameters : IBlocksAppendChildrenBodyParameters
-    {
-        public IEnumerable<BlockBase> Children { get; set; }
     }
 }

--- a/Src/Notion.Client/Api/Blocks/BlocksClient.cs
+++ b/Src/Notion.Client/Api/Blocks/BlocksClient.cs
@@ -8,6 +8,7 @@ namespace Notion.Client
     public interface IBlocksClient
     {
         Task<PaginatedList<BlockBase>> RetrieveChildrenAsync(string blockId, BlockRetrieveChildrenParameters parameters = null);
+        Task<BlockBase> AppendChildrenAsync(string blockId, BlocksAppendChildrenParameters parameters = null);
     }
 
     public class BlocksClient : IBlocksClient
@@ -38,6 +39,20 @@ namespace Notion.Client
 
             return await _client.GetAsync<PaginatedList<BlockBase>>(url, queryParams);
         }
+
+        public async Task<BlockBase> AppendChildrenAsync(string blockId, BlocksAppendChildrenParameters parameters = null)
+        {
+            if (string.IsNullOrWhiteSpace(blockId))
+            {
+                throw new ArgumentNullException(nameof(blockId));
+            }
+
+            var url = BlocksApiUrls.AppendChildren(blockId);
+
+            var body = (IBlocksAppendChildrenBodyParameters)parameters;
+
+            return await _client.PatchAsync<BlockBase>(url, body);
+        }
     }
 
     public interface IBlockRetrieveChildrenQueryParameters : IPaginationParameters
@@ -52,5 +67,17 @@ namespace Notion.Client
     {
         public string StartCursor { get; set; }
         public string PageSize { get; set; }
+    }
+
+
+    // TODO: need an input version of Block
+    public interface IBlocksAppendChildrenBodyParameters
+    {
+        IEnumerable<BlockBase> Children { get; set; }
+    }
+
+    public class BlocksAppendChildrenParameters : IBlocksAppendChildrenBodyParameters
+    {
+        public IEnumerable<BlockBase> Children { get; set; }
     }
 }

--- a/Src/Notion.Client/Api/Blocks/BlocksClient.cs
+++ b/Src/Notion.Client/Api/Blocks/BlocksClient.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using static Notion.Client.ApiEndpoints;
+
+namespace Notion.Client
+{
+    public interface IBlocksClient
+    {
+        Task<PaginatedList<BlockBase>> RetrieveChildrenAsync(string blockId, BlockRetrieveChildrenParameters parameters = null);
+    }
+
+    public class BlocksClient : IBlocksClient
+    {
+        private readonly IRestClient _client;
+
+        public BlocksClient(IRestClient client)
+        {
+            _client = client;
+        }
+
+        public async Task<PaginatedList<BlockBase>> RetrieveChildrenAsync(string blockId, BlockRetrieveChildrenParameters parameters = null)
+        {
+            if (string.IsNullOrWhiteSpace(blockId))
+            {
+                throw new ArgumentNullException(nameof(blockId));
+            }
+
+            var url = BlocksApiUrls.RetrieveChildren(blockId);
+
+            var queryParameters = (IBlockRetrieveChildrenQueryParameters)parameters;
+
+            var queryParams = new Dictionary<string, string>()
+            {
+                { "start_cursor", queryParameters?.StartCursor?.ToString() },
+                { "page_size", queryParameters?.PageSize?.ToString() }
+            };
+
+            return await _client.GetAsync<PaginatedList<BlockBase>>(url, queryParams);
+        }
+    }
+
+    public interface IBlockRetrieveChildrenQueryParameters : IPaginationParameters
+    {
+    }
+
+    public interface IBlockRetrieveChildrenParameters : IBlockRetrieveChildrenQueryParameters
+    {
+    }
+
+    public class BlockRetrieveChildrenParameters : IBlockRetrieveChildrenParameters
+    {
+        public string StartCursor { get; set; }
+        public string PageSize { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Blocks/BlocksRetrieveChildrenParameters.cs
+++ b/Src/Notion.Client/Api/Blocks/BlocksRetrieveChildrenParameters.cs
@@ -1,0 +1,12 @@
+namespace Notion.Client
+{
+    public interface IBlocksRetrieveChildrenQueryParameters : IPaginationParameters
+    {
+    }
+
+    public class BlocksRetrieveChildrenParameters : IBlocksRetrieveChildrenQueryParameters
+    {
+        public string StartCursor { get; set; }
+        public string PageSize { get; set; }
+    }
+}

--- a/Src/Notion.Client/Models/Block.cs
+++ b/Src/Notion.Client/Models/Block.cs
@@ -23,7 +23,7 @@ namespace Notion.Client
         public string Id { get; set; }
 
         [JsonConverter(typeof(StringEnumConverter))]
-        public BlockType Type { get; set; }
+        public virtual BlockType Type { get; set; }
 
         [JsonProperty("created_time")]
         public string CreatedTime { get; set; }
@@ -40,6 +40,8 @@ namespace Notion.Client
 
     public class ParagraphBlock : BlockBase
     {
+        public override BlockType Type => BlockType.Paragraph;
+
         public ParagraphClass Paragraph { get; set; }
 
         public class ParagraphClass
@@ -51,6 +53,8 @@ namespace Notion.Client
 
     public class HeadingOneBlock : BlockBase
     {
+        public override BlockType Type => BlockType.Heading_1;
+
         [JsonProperty("heading_1")]
         public HeadingOneClass Heading_1 { get; set; }
 
@@ -64,6 +68,8 @@ namespace Notion.Client
 
     public class HeadingTwoBlock : BlockBase
     {
+        public override BlockType Type => BlockType.Heading_2;
+
         [JsonProperty("heading_2")]
         public HeadingTwoClass Heading_2 { get; set; }
 
@@ -77,6 +83,8 @@ namespace Notion.Client
 
     public class HeadingThreeeBlock : BlockBase
     {
+        public override BlockType Type => BlockType.Heading_3;
+
         [JsonProperty("heading_3")]
         public HeadingThreeClass Heading_3 { get; set; }
 
@@ -90,6 +98,8 @@ namespace Notion.Client
 
     public class BulletedListItemBlock : BlockBase
     {
+        public override BlockType Type => BlockType.BulletedListItem;
+
         [JsonProperty("bulleted_list_item")]
         public BulletedListItemClass BulletedListItem { get; set; }
 
@@ -103,6 +113,8 @@ namespace Notion.Client
     public class NumberedListItemBlock : BlockBase
     {
 
+        public override BlockType Type => BlockType.NumberedListItem;
+
         [JsonProperty("numbered_list_item")]
         public NumberedListItemClass NumberedListItem { get; set; }
 
@@ -115,6 +127,8 @@ namespace Notion.Client
 
     public class ToDoBlock : BlockBase
     {
+        public override BlockType Type => BlockType.ToDo;
+
         [JsonProperty("to_do")]
         public ToDoClass ToDo { get; set; }
 
@@ -131,6 +145,8 @@ namespace Notion.Client
 
     public class ToggleBlock : BlockBase
     {
+        public override BlockType Type => BlockType.Toggle;
+
         public ToggleClass Toggle { get; set; }
 
         public class ToggleClass
@@ -142,6 +158,8 @@ namespace Notion.Client
 
     public class ChildPageBlock : BlockBase
     {
+        public override BlockType Type => BlockType.ChildPage;
+
 
         [JsonProperty("child_page")]
         public ChildPageClass ChildPage { get; set; }
@@ -154,6 +172,7 @@ namespace Notion.Client
 
     public class UnsupportedBlock : BlockBase
     {
+        public override BlockType Type => BlockType.Unsupported;
     }
 
     public enum BlockType

--- a/Src/Notion.Client/Models/Block.cs
+++ b/Src/Notion.Client/Models/Block.cs
@@ -1,0 +1,191 @@
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using JsonSubTypes;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Notion.Client
+{
+    [JsonConverter(typeof(JsonSubtypes), "type")]
+    [JsonSubtypes.KnownSubType(typeof(BulletedListItemBlock), BlockType.BulletedListItem)]
+    [JsonSubtypes.KnownSubType(typeof(ChildPageBlock), BlockType.ChildPage)]
+    [JsonSubtypes.KnownSubType(typeof(HeadingOneBlock), BlockType.Heading_1)]
+    [JsonSubtypes.KnownSubType(typeof(HeadingTwoBlock), BlockType.Heading_2)]
+    [JsonSubtypes.KnownSubType(typeof(HeadingThreeeBlock), BlockType.Heading_3)]
+    [JsonSubtypes.KnownSubType(typeof(NumberedListItemBlock), BlockType.NumberedListItem)]
+    [JsonSubtypes.KnownSubType(typeof(ParagraphBlock), BlockType.Paragraph)]
+    [JsonSubtypes.KnownSubType(typeof(ToDoBlock), BlockType.ToDo)]
+    [JsonSubtypes.KnownSubType(typeof(ToggleBlock), BlockType.Toggle)]
+    [JsonSubtypes.KnownSubType(typeof(UnsupportedBlock), BlockType.Unsupported)]
+    public class BlockBase
+    {
+        public string Object => "block";
+        public string Id { get; set; }
+
+        [JsonConverter(typeof(StringEnumConverter))]
+        public BlockType Type { get; set; }
+
+        [JsonProperty("created_time")]
+        public string CreatedTime { get; set; }
+
+
+        [JsonProperty("last_edited_time")]
+        public string LastEditedTime { get; set; }
+
+
+        [JsonProperty("has_children")]
+        public virtual bool HasChildren { get; set; }
+
+    }
+
+    public class ParagraphBlock : BlockBase
+    {
+        public ParagraphClass Paragraph { get; set; }
+
+        public class ParagraphClass
+        {
+            public IEnumerable<RichTextBase> Text { get; set; }
+            public IEnumerable<BlockBase> Children { get; set; }
+        }
+    }
+
+    public class HeadingOneBlock : BlockBase
+    {
+        [JsonProperty("heading_1")]
+        public HeadingOneClass Heading_1 { get; set; }
+
+        public override bool HasChildren => false;
+
+        public class HeadingOneClass
+        {
+            public IEnumerable<RichTextBase> Text { get; set; }
+        }
+    }
+
+    public class HeadingTwoBlock : BlockBase
+    {
+        [JsonProperty("heading_2")]
+        public HeadingTwoClass Heading_2 { get; set; }
+
+        public override bool HasChildren => false;
+
+        public class HeadingTwoClass
+        {
+            public IEnumerable<RichTextBase> Text { get; set; }
+        }
+    }
+
+    public class HeadingThreeeBlock : BlockBase
+    {
+        [JsonProperty("heading_3")]
+        public HeadingThreeClass Heading_3 { get; set; }
+
+        public override bool HasChildren => false;
+
+        public class HeadingThreeClass
+        {
+            public IEnumerable<RichTextBase> Text { get; set; }
+        }
+    }
+
+    public class BulletedListItemBlock : BlockBase
+    {
+        [JsonProperty("bulleted_list_item")]
+        public BulletedListItemClass BulletedListItem { get; set; }
+
+        public class BulletedListItemClass
+        {
+            public IEnumerable<RichTextBase> Text { get; set; }
+            public IEnumerable<BlockBase> Children { get; set; }
+        }
+    }
+
+    public class NumberedListItemBlock : BlockBase
+    {
+
+        [JsonProperty("numbered_list_item")]
+        public NumberedListItemClass NumberedListItem { get; set; }
+
+        public class NumberedListItemClass
+        {
+            public IEnumerable<RichTextBase> Text { get; set; }
+            public IEnumerable<BlockBase> Children { get; set; }
+        }
+    }
+
+    public class ToDoBlock : BlockBase
+    {
+        [JsonProperty("to_do")]
+        public ToDoClass ToDo { get; set; }
+
+        public class ToDoClass
+        {
+            public IEnumerable<RichTextBase> Text { get; set; }
+
+            [JsonProperty("checked")]
+            public bool IsChecked { get; set; }
+
+            public IEnumerable<BlockBase> Children { get; set; }
+        }
+    }
+
+    public class ToggleBlock : BlockBase
+    {
+        public ToggleClass Toggle { get; set; }
+
+        public class ToggleClass
+        {
+            public IEnumerable<RichTextBase> Text { get; set; }
+            public IEnumerable<BlockBase> Children { get; set; }
+        }
+    }
+
+    public class ChildPageBlock : BlockBase
+    {
+
+        [JsonProperty("child_page")]
+        public ChildPageClass ChildPage { get; set; }
+
+        public class ChildPageClass
+        {
+            public string Title { get; set; }
+        }
+    }
+
+    public class UnsupportedBlock : BlockBase
+    {
+    }
+
+    public enum BlockType
+    {
+        [EnumMember(Value = "paragraph")]
+        Paragraph,
+
+        [EnumMember(Value = "heading_1")]
+        Heading_1,
+
+        [EnumMember(Value = "heading_2")]
+        Heading_2,
+
+        [EnumMember(Value = "heading_3")]
+        Heading_3,
+
+        [EnumMember(Value = "bulleted_list_item")]
+        BulletedListItem,
+
+        [EnumMember(Value = "numbered_list_item")]
+        NumberedListItem,
+
+        [EnumMember(Value = "to_do")]
+        ToDo,
+
+        [EnumMember(Value = "toggle")]
+        Toggle,
+
+        [EnumMember(Value = "child_page")]
+        ChildPage,
+
+        [EnumMember(Value = "unsupported")]
+        Unsupported
+    }
+}

--- a/Src/Notion.Client/Models/Block.cs
+++ b/Src/Notion.Client/Models/Block.cs
@@ -28,10 +28,8 @@ namespace Notion.Client
         [JsonProperty("created_time")]
         public string CreatedTime { get; set; }
 
-
         [JsonProperty("last_edited_time")]
         public string LastEditedTime { get; set; }
-
 
         [JsonProperty("has_children")]
         public virtual bool HasChildren { get; set; }
@@ -111,7 +109,6 @@ namespace Notion.Client
 
     public class NumberedListItemBlock : BlockBase
     {
-
         public override BlockType Type => BlockType.NumberedListItem;
 
         [JsonProperty("numbered_list_item")]

--- a/Src/Notion.Client/Models/Block.cs
+++ b/Src/Notion.Client/Models/Block.cs
@@ -35,7 +35,6 @@ namespace Notion.Client
 
         [JsonProperty("has_children")]
         public virtual bool HasChildren { get; set; }
-
     }
 
     public class ParagraphBlock : BlockBase
@@ -159,7 +158,6 @@ namespace Notion.Client
     public class ChildPageBlock : BlockBase
     {
         public override BlockType Type => BlockType.ChildPage;
-
 
         [JsonProperty("child_page")]
         public ChildPageClass ChildPage { get; set; }

--- a/Src/Notion.Client/Models/PaginatedList.cs
+++ b/Src/Notion.Client/Models/PaginatedList.cs
@@ -11,7 +11,7 @@ namespace Notion.Client
 
     public class PaginatedList<T>
     {
-        public const string Object = "List";
+        public const string Object = "list";
 
         public List<T> Results { get; set; }
 

--- a/Test/Notion.UnitTests/BlocksClientTests.cs
+++ b/Test/Notion.UnitTests/BlocksClientTests.cs
@@ -24,7 +24,7 @@ namespace Notion.UnitTests
         {
             string blockId = "3c357473-a281-49a4-88c0-10d2b245a589";
 
-            var children = await _client.RetrieveChildrenAsync(blockId, new BlockRetrieveChildrenParameters());
+            var children = await _client.RetrieveChildrenAsync(blockId, new BlocksRetrieveChildrenParameters());
 
             Assert.NotNull(children);
         }

--- a/Test/Notion.UnitTests/BlocksClientTests.cs
+++ b/Test/Notion.UnitTests/BlocksClientTests.cs
@@ -1,0 +1,31 @@
+using System.Threading.Tasks;
+using Notion.Client;
+using Xunit;
+
+namespace Notion.UnitTests
+{
+    public class BlocksClientTests
+    {
+        private readonly IBlocksClient _client;
+
+        public BlocksClientTests()
+        {
+            var options = new ClientOptions()
+            {
+                AuthToken = "<Token>"
+            };
+
+            _client = new BlocksClient(new RestClient(options));
+        }
+
+        [Fact(Skip ="Dev only")]
+        public async Task RetrieveBlockChildren()
+        {
+            string blockId = "3c357473-a281-49a4-88c0-10d2b245a589";
+            
+            var children = await _client.RetrieveChildrenAsync(blockId, new BlockRetrieveChildrenParameters());
+
+            Assert.NotNull(children);
+        }
+    }
+}

--- a/Test/Notion.UnitTests/BlocksClientTests.cs
+++ b/Test/Notion.UnitTests/BlocksClientTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Notion.Client;
 using Xunit;
@@ -18,14 +19,47 @@ namespace Notion.UnitTests
             _client = new BlocksClient(new RestClient(options));
         }
 
-        [Fact(Skip ="Dev only")]
+        [Fact(Skip = "Dev only")]
         public async Task RetrieveBlockChildren()
         {
             string blockId = "3c357473-a281-49a4-88c0-10d2b245a589";
-            
+
             var children = await _client.RetrieveChildrenAsync(blockId, new BlockRetrieveChildrenParameters());
 
             Assert.NotNull(children);
+        }
+
+        [Fact(Skip = "Dev only")]
+        public async Task AppendBlockChildren()
+        {
+            string blockId = "3c357473-a281-49a4-88c0-10d2b245a589";
+
+            var parameters = new BlocksAppendChildrenParameters()
+            {
+                Children = new List<BlockBase>
+                {
+                    new HeadingTwoBlock()
+                    {
+                        Heading_2 = new HeadingTwoBlock.HeadingTwoClass
+                        {
+                            Text = new List<RichTextBase>
+                            {
+                                new RichTextText
+                                {
+                                    Text = new Text
+                                    {
+                                        Content = "Lacinato kale"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            var block = await _client.AppendChildrenAsync(blockId, parameters);
+
+            Assert.NotNull(block);
         }
     }
 }


### PR DESCRIPTION
#3 

A block object represents content within Notion. Blocks can be text, lists, media, and more. A page is a type of block, too!

API's
- [x] Retrieve block children
- [x] Append block children

ref: https://developers.notion.com/reference/block