### PR TITLE
Replace code snippet images with actual code

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,18 @@ dotnet add package Notion.Net
 
 Import and initialize the client using the integration token created above.
 
-![image](https://user-images.githubusercontent.com/18693839/119268863-79925b00-bc12-11eb-92cb-d5a9a8c57fdc.png)
+```csharp
+var client = new NotionClient(new ClientOptions
+{
+    AuthToken = "<Token>"
+});
+```
 
 Make A request to any Endpoint. For example you can call below to fetch the paginated list of users.
 
-![image](https://user-images.githubusercontent.com/18693839/119268924-ae9ead80-bc12-11eb-9d1a-925267896d9e.png)
+```csharp
+var usersList = await client.Users.ListAsync();
+```
 
 ### Querying a database
 


### PR DESCRIPTION
Instead of adding the images of the code snippet which doesn't allow users to copy the code replaced it with code blocks. So it is easier to fix them and also users can copy the code if needed.