### PR TITLE
Add support for Search apis

### DIFF
--- a/Src/Notion.Client/Api/ApiEndpoints.cs
+++ b/Src/Notion.Client/Api/ApiEndpoints.cs
@@ -20,5 +20,10 @@
             public static string RetrieveChildren(string blockId) => $"/v1/blocks/{blockId}/children";
             public static string AppendChildren(string blockId) => $"/v1/blocks/{blockId}/children";
         }
+
+        public static class SearchApiUrls
+        {
+            public static string Search() => "/v1/search";
+        }
     }
 }

--- a/Src/Notion.Client/Api/Search/ISearchClient.cs
+++ b/Src/Notion.Client/Api/Search/ISearchClient.cs
@@ -1,4 +1,4 @@
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace Notion.Client
 {

--- a/Src/Notion.Client/Api/Search/ISearchClient.cs
+++ b/Src/Notion.Client/Api/Search/ISearchClient.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace Notion.Client
+{
+    public interface ISearchClient
+    {
+        Task<PaginatedList<IObject>> SearchAsync(SearchParameters parameters);
+    }
+}

--- a/Src/Notion.Client/Api/Search/Parameters/ISearchBodyParameters.cs
+++ b/Src/Notion.Client/Api/Search/Parameters/ISearchBodyParameters.cs
@@ -1,4 +1,4 @@
-namespace Notion.Client
+﻿namespace Notion.Client
 {
     public interface ISearchBodyParameters : IPaginationParameters
     {

--- a/Src/Notion.Client/Api/Search/Parameters/ISearchBodyParameters.cs
+++ b/Src/Notion.Client/Api/Search/Parameters/ISearchBodyParameters.cs
@@ -1,0 +1,9 @@
+namespace Notion.Client
+{
+    public interface ISearchBodyParameters : IPaginationParameters
+    {
+        string Query { get; set; }
+        SearchSort Sort { get; set; }
+        SearchFilter Filter { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Search/Parameters/SearchDirection.cs
+++ b/Src/Notion.Client/Api/Search/Parameters/SearchDirection.cs
@@ -1,4 +1,4 @@
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 
 namespace Notion.Client
 {

--- a/Src/Notion.Client/Api/Search/Parameters/SearchDirection.cs
+++ b/Src/Notion.Client/Api/Search/Parameters/SearchDirection.cs
@@ -1,0 +1,13 @@
+using System.Runtime.Serialization;
+
+namespace Notion.Client
+{
+    public enum SearchDirection
+    {
+        [EnumMember(Value = "ascending")]
+        Ascending,
+
+        [EnumMember(Value = "descending")]
+        Descending
+    }
+}

--- a/Src/Notion.Client/Api/Search/Parameters/SearchFilter.cs
+++ b/Src/Notion.Client/Api/Search/Parameters/SearchFilter.cs
@@ -1,0 +1,8 @@
+namespace Notion.Client
+{
+    public class SearchFilter
+    {
+        public SearchObjectType Value { get; set; }
+        public string Property => "object";
+    }
+}

--- a/Src/Notion.Client/Api/Search/Parameters/SearchFilter.cs
+++ b/Src/Notion.Client/Api/Search/Parameters/SearchFilter.cs
@@ -1,4 +1,4 @@
-namespace Notion.Client
+﻿namespace Notion.Client
 {
     public class SearchFilter
     {

--- a/Src/Notion.Client/Api/Search/Parameters/SearchObjectType.cs
+++ b/Src/Notion.Client/Api/Search/Parameters/SearchObjectType.cs
@@ -1,4 +1,4 @@
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 
 namespace Notion.Client
 {

--- a/Src/Notion.Client/Api/Search/Parameters/SearchObjectType.cs
+++ b/Src/Notion.Client/Api/Search/Parameters/SearchObjectType.cs
@@ -1,0 +1,13 @@
+using System.Runtime.Serialization;
+
+namespace Notion.Client
+{
+    public enum SearchObjectType
+    {
+        [EnumMember(Value = "page")]
+        Page,
+
+        [EnumMember(Value = "database")]
+        Database
+    }
+}

--- a/Src/Notion.Client/Api/Search/Parameters/SearchParameters.cs
+++ b/Src/Notion.Client/Api/Search/Parameters/SearchParameters.cs
@@ -1,0 +1,11 @@
+namespace Notion.Client
+{
+    public class SearchParameters : ISearchBodyParameters
+    {
+        public string Query { get; set; }
+        public SearchSort Sort { get; set; }
+        public SearchFilter Filter { get; set; }
+        public string StartCursor { get; set; }
+        public string PageSize { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Search/Parameters/SearchParameters.cs
+++ b/Src/Notion.Client/Api/Search/Parameters/SearchParameters.cs
@@ -1,4 +1,4 @@
-namespace Notion.Client
+﻿namespace Notion.Client
 {
     public class SearchParameters : ISearchBodyParameters
     {

--- a/Src/Notion.Client/Api/Search/Parameters/SearchSort.cs
+++ b/Src/Notion.Client/Api/Search/Parameters/SearchSort.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 

--- a/Src/Notion.Client/Api/Search/Parameters/SearchSort.cs
+++ b/Src/Notion.Client/Api/Search/Parameters/SearchSort.cs
@@ -1,0 +1,14 @@
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Notion.Client
+{
+    public class SearchSort
+    {
+        public SearchDirection Direction { get; set; }
+
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTime Timestamp { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Search/SearchClient.cs
+++ b/Src/Notion.Client/Api/Search/SearchClient.cs
@@ -1,4 +1,4 @@
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using static Notion.Client.ApiEndpoints;
 
 namespace Notion.Client

--- a/Src/Notion.Client/Api/Search/SearchClient.cs
+++ b/Src/Notion.Client/Api/Search/SearchClient.cs
@@ -1,0 +1,24 @@
+using System.Threading.Tasks;
+using static Notion.Client.ApiEndpoints;
+
+namespace Notion.Client
+{
+    public class SearchClient : ISearchClient
+    {
+        private readonly IRestClient client;
+
+        public SearchClient(IRestClient client)
+        {
+            this.client = client;
+        }
+
+        public async Task<PaginatedList<IObject>> SearchAsync(SearchParameters parameters)
+        {
+            var url = SearchApiUrls.Search();
+
+            var body = (ISearchBodyParameters)parameters;
+
+            return await client.PostAsync<PaginatedList<IObject>>(url, body);
+        }
+    }
+}

--- a/Src/Notion.Client/Models/Blocks/Block.cs
+++ b/Src/Notion.Client/Models/Blocks/Block.cs
@@ -15,7 +15,7 @@ namespace Notion.Client
     [JsonSubtypes.KnownSubType(typeof(ToDoBlock), BlockType.ToDo)]
     [JsonSubtypes.KnownSubType(typeof(ToggleBlock), BlockType.Toggle)]
     [JsonSubtypes.KnownSubType(typeof(UnsupportedBlock), BlockType.Unsupported)]
-    public class Block
+    public class Block : IObject
     {
         public ObjectType Object => ObjectType.Block;
         public string Id { get; set; }

--- a/Src/Notion.Client/Models/Blocks/Block.cs
+++ b/Src/Notion.Client/Models/Blocks/Block.cs
@@ -17,7 +17,7 @@ namespace Notion.Client
     [JsonSubtypes.KnownSubType(typeof(UnsupportedBlock), BlockType.Unsupported)]
     public class Block
     {
-        public string Object => "block";
+        public ObjectType Object => ObjectType.Block;
         public string Id { get; set; }
 
         [JsonConverter(typeof(StringEnumConverter))]

--- a/Src/Notion.Client/Models/Database/Database.cs
+++ b/Src/Notion.Client/Models/Database/Database.cs
@@ -6,7 +6,7 @@ namespace Notion.Client
 {
     public class Database
     {
-        public string Object => "database";
+        public ObjectType Object => ObjectType.Database;
         public string Id { get; set; }
 
         [JsonProperty("created_time")]

--- a/Src/Notion.Client/Models/Database/Database.cs
+++ b/Src/Notion.Client/Models/Database/Database.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 
 namespace Notion.Client
 {
-    public class Database
+    public class Database : IObject
     {
         public ObjectType Object => ObjectType.Database;
         public string Id { get; set; }

--- a/Src/Notion.Client/Models/IObject.cs
+++ b/Src/Notion.Client/Models/IObject.cs
@@ -1,0 +1,16 @@
+using JsonSubTypes;
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    [JsonConverter(typeof(JsonSubtypes), "object")]
+    [JsonSubtypes.KnownSubType(typeof(Page), ObjectType.Page)]
+    [JsonSubtypes.KnownSubType(typeof(Database), ObjectType.Database)]
+    [JsonSubtypes.KnownSubType(typeof(Block), ObjectType.Block)]
+    [JsonSubtypes.KnownSubType(typeof(User), ObjectType.User)]
+    public interface IObject
+    {
+        string Id { get; set; }
+        ObjectType Object { get; }
+    }
+}

--- a/Src/Notion.Client/Models/IObject.cs
+++ b/Src/Notion.Client/Models/IObject.cs
@@ -1,4 +1,4 @@
-using JsonSubTypes;
+﻿using JsonSubTypes;
 using Newtonsoft.Json;
 
 namespace Notion.Client

--- a/Src/Notion.Client/Models/ObjectType.cs
+++ b/Src/Notion.Client/Models/ObjectType.cs
@@ -1,0 +1,19 @@
+using System.Runtime.Serialization;
+
+namespace Notion.Client
+{
+    public enum ObjectType
+    {
+        [EnumMember(Value = "page")]
+        Page,
+
+        [EnumMember(Value = "database")]
+        Database,
+
+        [EnumMember(Value = "block")]
+        Block,
+
+        [EnumMember(Value = "user")]
+        User,
+    }
+}

--- a/Src/Notion.Client/Models/ObjectType.cs
+++ b/Src/Notion.Client/Models/ObjectType.cs
@@ -1,4 +1,4 @@
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 
 namespace Notion.Client
 {

--- a/Src/Notion.Client/Models/Page/Page.cs
+++ b/Src/Notion.Client/Models/Page/Page.cs
@@ -6,7 +6,7 @@ namespace Notion.Client
 {
     public class Page
     {
-        public string Object => "page";
+        public ObjectType Object => ObjectType.Page;
         public string Id { get; set; }
         public Parent Parent { get; set; }
 

--- a/Src/Notion.Client/Models/Page/Page.cs
+++ b/Src/Notion.Client/Models/Page/Page.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 
 namespace Notion.Client
 {
-    public class Page
+    public class Page : IObject
     {
         public ObjectType Object => ObjectType.Page;
         public string Id { get; set; }

--- a/Src/Notion.Client/Models/PaginatedList.cs
+++ b/Src/Notion.Client/Models/PaginatedList.cs
@@ -5,7 +5,10 @@ namespace Notion.Client
 {
     public interface IPaginationParameters
     {
+        [JsonProperty("start_cursor")]
         string StartCursor { get; set; }
+
+        [JsonProperty("page_size")]
         string PageSize { get; set; }
     }
 

--- a/Src/Notion.Client/Models/User.cs
+++ b/Src/Notion.Client/Models/User.cs
@@ -2,7 +2,7 @@
 
 namespace Notion.Client
 {
-    public class User
+    public class User : IObject
     {
         public ObjectType Object => ObjectType.User;
         public string Id { get; set; }

--- a/Src/Notion.Client/Models/User.cs
+++ b/Src/Notion.Client/Models/User.cs
@@ -4,7 +4,7 @@ namespace Notion.Client
 {
     public class User
     {
-        public string Object => "user";
+        public ObjectType Object => ObjectType.User;
         public string Id { get; set; }
         public string Type { get; set; }
         public string Name { get; set; }

--- a/Src/Notion.Client/NotionClient.cs
+++ b/Src/Notion.Client/NotionClient.cs
@@ -4,6 +4,7 @@
     {
         IUsersClient Users { get; }
         IDatabasesClient Databases { get; }
+        ISearchClient Search { get; }
     }
 
     public class NotionClient : INotionClient
@@ -13,9 +14,11 @@
             var restClient = new RestClient(options);
             Users = new UsersClient(restClient);
             Databases = new DatabasesClient(restClient);
+            Search = new SearchClient(restClient);
         }
 
         public IUsersClient Users { get; }
         public IDatabasesClient Databases { get; }
+        public ISearchClient Search { get; }
     }
 }


### PR DESCRIPTION
API's
- [x] Search

Search API at the moment returns the Paginated list of Pages or Database based on the filter. Hence I introduced the IObject interface which every notion object implements which allows return IObject interface.

ref: https://developers.notion.com/reference/post-search