### PR TITLE
Parse error response and make it available in exception

### DIFF
--- a/Src/Notion.Client/NotionAPIErrorCode.cs
+++ b/Src/Notion.Client/NotionAPIErrorCode.cs
@@ -1,0 +1,43 @@
+﻿using System.Runtime.Serialization;
+
+namespace Notion.Client
+{
+    public enum NotionAPIErrorCode
+    {
+        [EnumMember(Value = "invalid_json")]
+        InvalidJSON,
+
+        [EnumMember(Value = "invalid_request_url")]
+        InvalidRequestURL,
+
+        [EnumMember(Value = "invalid_request")]
+        InvalidRequest,
+
+        [EnumMember(Value = "validation_error")]
+        ValidationError,
+
+        [EnumMember(Value = "missing_version")]
+        MissingVersion,
+
+        [EnumMember(Value = "unauthorized")]
+        Unauthorized,
+
+        [EnumMember(Value = "restricted_resource")]
+        RestrictedResource,
+
+        [EnumMember(Value = "object_not_found")]
+        ObjectNotFound,
+
+        [EnumMember(Value = "conflict_error")]
+        ConflictError,
+
+        [EnumMember(Value = "rate_limited")]
+        RateLimited,
+
+        [EnumMember(Value = "internal_server_error")]
+        InternalServerError,
+
+        [EnumMember(Value = "service_unavailable")]
+        ServiceUnavailable,
+    }
+}

--- a/Src/Notion.Client/NotionApiErrorResponse.cs
+++ b/Src/Notion.Client/NotionApiErrorResponse.cs
@@ -1,0 +1,8 @@
+﻿namespace Notion.Client
+{
+    class NotionApiErrorResponse
+    {
+        public NotionAPIErrorCode ErrorCode { get; set; }
+        public string Message { get; set; }
+    }
+}

--- a/Src/Notion.Client/NotionApiException.cs
+++ b/Src/Notion.Client/NotionApiException.cs
@@ -3,15 +3,32 @@ using System.Net;
 
 namespace Notion.Client
 {
-    class NotionApiException : Exception
+    public class NotionApiException : Exception
     {
-        public NotionApiException(HttpStatusCode statusCode, string message) : this(statusCode, message, null)
+        public NotionApiException(HttpStatusCode statusCode, NotionAPIErrorCode? notionAPIErrorCode, string message)
+            : this(statusCode, notionAPIErrorCode, message, null)
         {
         }
 
-        public NotionApiException(HttpStatusCode statusCode, string message, Exception innerException) : base(message, innerException)
+        public NotionApiException(HttpStatusCode statusCode, string message)
+            : this(statusCode, null, message, null)
         {
-            Data.Add("StatusCode", statusCode);
         }
+
+        public NotionApiException(
+            HttpStatusCode statusCode,
+            NotionAPIErrorCode? notionAPIErrorCode,
+            string message,
+            Exception innerException) : base(message, innerException)
+        {
+            NotionAPIErrorCode = notionAPIErrorCode;
+            StatusCode = statusCode;
+
+            Data.Add("StatusCode", statusCode);
+            Data.Add("NotionApiErrorCode", NotionAPIErrorCode);
+        }
+
+        public NotionAPIErrorCode? NotionAPIErrorCode { get; }
+        public HttpStatusCode StatusCode { get; }
     }
 }

--- a/Src/Notion.Client/RestClient/RestClient.cs
+++ b/Src/Notion.Client/RestClient/RestClient.cs
@@ -48,8 +48,6 @@ namespace Notion.Client
             JsonSerializerSettings serializerSettings = null,
             CancellationToken cancellationToken = default)
         {
-            EnsureHttpClient();
-
             var response = await SendAsync(uri, HttpMethod.Get, queryParams, headers, cancellationToken: cancellationToken);
 
             return await response.ParseStreamAsync<T>(serializerSettings);
@@ -82,6 +80,8 @@ namespace Notion.Client
             Action<HttpRequestMessage> attachContent = null,
             CancellationToken cancellationToken = default)
         {
+            EnsureHttpClient();
+
             requestUri = AddQueryString(requestUri, queryParams);
 
             HttpRequestMessage httpRequest = new HttpRequestMessage(httpMethod, requestUri);
@@ -121,8 +121,6 @@ namespace Notion.Client
             JsonSerializerSettings serializerSettings = null,
             CancellationToken cancellationToken = default)
         {
-            EnsureHttpClient();
-
             void AttachContent(HttpRequestMessage httpRequest)
             {
                 httpRequest.Content = new StringContent(JsonConvert.SerializeObject(body, defaultSerializerSettings), Encoding.UTF8, "application/json");
@@ -135,8 +133,6 @@ namespace Notion.Client
 
         public async Task<T> PatchAsync<T>(string uri, object body, IDictionary<string, string> queryParams = null, IDictionary<string, string> headers = null, JsonSerializerSettings serializerSettings = null, CancellationToken cancellationToken = default)
         {
-            EnsureHttpClient();
-
             void AttachContent(HttpRequestMessage httpRequest)
             {
                 var serializedBody = JsonConvert.SerializeObject(body, defaultSerializerSettings);

--- a/Src/Notion.Client/RestClient/RestClient.cs
+++ b/Src/Notion.Client/RestClient/RestClient.cs
@@ -50,9 +50,7 @@ namespace Notion.Client
         {
             EnsureHttpClient();
 
-            string requestUri = queryParams == null ? uri : QueryHelpers.AddQueryString(uri, queryParams);
-
-            var response = await SendAsync(requestUri, HttpMethod.Get, headers, cancellationToken: cancellationToken);
+            var response = await SendAsync(uri, HttpMethod.Get, queryParams, headers, cancellationToken: cancellationToken);
 
             return await response.ParseStreamAsync<T>(serializerSettings);
         }
@@ -79,10 +77,13 @@ namespace Notion.Client
         private async Task<HttpResponseMessage> SendAsync(
             string requestUri,
             HttpMethod httpMethod,
+            IDictionary<string, string> queryParams = null,
             IDictionary<string, string> headers = null,
             Action<HttpRequestMessage> attachContent = null,
             CancellationToken cancellationToken = default)
         {
+            requestUri = AddQueryString(requestUri, queryParams);
+
             HttpRequestMessage httpRequest = new HttpRequestMessage(httpMethod, requestUri);
             httpRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _options.AuthToken);
             httpRequest.Headers.Add("Notion-Version", _options.NotionVersion);
@@ -127,9 +128,7 @@ namespace Notion.Client
                 httpRequest.Content = new StringContent(JsonConvert.SerializeObject(body, defaultSerializerSettings), Encoding.UTF8, "application/json");
             }
 
-            string requestUri = queryParams == null ? uri : QueryHelpers.AddQueryString(uri, queryParams);
-
-            var response = await SendAsync(requestUri, HttpMethod.Post, headers, AttachContent, cancellationToken: cancellationToken);
+            var response = await SendAsync(uri, HttpMethod.Post, queryParams, headers, AttachContent, cancellationToken: cancellationToken);
 
             return await response.ParseStreamAsync<T>(serializerSettings);
         }
@@ -144,9 +143,7 @@ namespace Notion.Client
                 httpRequest.Content = new StringContent(serializedBody, Encoding.UTF8, "application/json");
             }
 
-            string requestUri = queryParams == null ? uri : QueryHelpers.AddQueryString(uri, queryParams);
-
-            var response = await SendAsync(requestUri, new HttpMethod("PATCH"), headers, AttachContent, cancellationToken: cancellationToken);
+            var response = await SendAsync(uri, new HttpMethod("PATCH"), queryParams, headers, AttachContent, cancellationToken: cancellationToken);
 
             return await response.ParseStreamAsync<T>(serializerSettings);
         }
@@ -160,6 +157,11 @@ namespace Notion.Client
             }
 
             return _httpClient;
+        }
+
+        private static string AddQueryString(string uri, IDictionary<string, string> queryParams)
+        {
+            return queryParams == null ? uri : QueryHelpers.AddQueryString(uri, queryParams);
         }
     }
 }


### PR DESCRIPTION
Responses from the API use HTTP response codes are used to indicate general classes of success and error. Error responses contain more detail about the error in the response body, in the "code" and "message" properties.

https://developers.notion.com/reference/errors