### PR TITLE
Fix 'errorResponse' is null on at least one execution path. :bug:

### DIFF
--- a/Src/Notion.Client/RestClient/RestClient.cs
+++ b/Src/Notion.Client/RestClient/RestClient.cs
@@ -69,7 +69,7 @@ namespace Notion.Client
                 }
             }
 
-            return new NotionApiException(response.StatusCode, errorResponse?.ErrorCode, errorResponse.Message);
+            return new NotionApiException(response.StatusCode, errorResponse?.ErrorCode, errorResponse?.Message);
         }
 
         private async Task<HttpResponseMessage> SendAsync(


### PR DESCRIPTION
Fix #40 