### PR TITLE
Database objects now returns parent property

### DIFF
--- a/Src/Notion.Client/Models/Database/Database.cs
+++ b/Src/Notion.Client/Models/Database/Database.cs
@@ -7,6 +7,7 @@ namespace Notion.Client
     public class Database : IObject
     {
         public ObjectType Object => ObjectType.Database;
+
         public string Id { get; set; }
 
         [JsonProperty("created_time")]
@@ -18,5 +19,7 @@ namespace Notion.Client
         public List<RichTextBase> Title { get; set; }
 
         public Dictionary<string, Property> Properties { get; set; }
+
+        public IDatabaseParent Parent { get; set; }
     }
 }

--- a/Src/Notion.Client/Models/Database/IDatabaseParent.cs
+++ b/Src/Notion.Client/Models/Database/IDatabaseParent.cs
@@ -1,0 +1,12 @@
+﻿using JsonSubTypes;
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    [JsonConverter(typeof(JsonSubtypes), "type")]
+    [JsonSubtypes.KnownSubType(typeof(PageParent), ParentType.PageId)]
+    [JsonSubtypes.KnownSubType(typeof(WorkspaceParent), ParentType.Workspace)]
+    public interface IDatabaseParent : IParent
+    {
+    }
+}

--- a/Src/Notion.Client/Models/Page/IPageParent.cs
+++ b/Src/Notion.Client/Models/Page/IPageParent.cs
@@ -1,6 +1,5 @@
 ﻿using JsonSubTypes;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 
 namespace Notion.Client
 {
@@ -8,9 +7,7 @@ namespace Notion.Client
     [JsonSubtypes.KnownSubType(typeof(DatabaseParent), ParentType.DatabaseId)]
     [JsonSubtypes.KnownSubType(typeof(PageParent), ParentType.PageId)]
     [JsonSubtypes.KnownSubType(typeof(WorkspaceParent), ParentType.Workspace)]
-    public class Parent
+    public interface IPageParent : IParent
     {
-        [JsonConverter(typeof(StringEnumConverter))]
-        public ParentType Type { get; set; }
     }
 }

--- a/Src/Notion.Client/Models/Page/NewPage.cs
+++ b/Src/Notion.Client/Models/Page/NewPage.cs
@@ -17,14 +17,14 @@ namespace Notion.Client
         /// Constructor that adds required <c>Parent</c> property. Used when you don't want to
         /// assign properties in separate operations.
         /// </summary>
-        public NewPage(Parent parent)
+        public NewPage(IPageParent parent)
         {
             Parent = parent;
             Properties = new Dictionary<string, PropertyValue>();
             Children = new List<Block>();
         }
 
-        public Parent Parent { get; set; }
+        public IPageParent Parent { get; set; }
 
         public Dictionary<string, PropertyValue> Properties { get; set; }
 

--- a/Src/Notion.Client/Models/Page/Page.cs
+++ b/Src/Notion.Client/Models/Page/Page.cs
@@ -7,8 +7,10 @@ namespace Notion.Client
     public class Page : IObject
     {
         public ObjectType Object => ObjectType.Page;
+
         public string Id { get; set; }
-        public Parent Parent { get; set; }
+
+        public IPageParent Parent { get; set; }
 
         [JsonProperty("created_time")]
         public DateTime CreatedTime { get; set; }

--- a/Src/Notion.Client/Models/Page/WorkspaceParent.cs
+++ b/Src/Notion.Client/Models/Page/WorkspaceParent.cs
@@ -1,6 +1,0 @@
-﻿namespace Notion.Client
-{
-    public class WorkspaceParent : Parent
-    {
-    }
-}

--- a/Src/Notion.Client/Models/Parents/DatabaseParent.cs
+++ b/Src/Notion.Client/Models/Parents/DatabaseParent.cs
@@ -2,8 +2,10 @@
 
 namespace Notion.Client
 {
-    public class DatabaseParent : Parent
+    public class DatabaseParent : IPageParent
     {
+        public ParentType Type { get; set; }
+
         [JsonProperty("database_id")]
         public string DatabaseId { get; set; }
     }

--- a/Src/Notion.Client/Models/Parents/IParent.cs
+++ b/Src/Notion.Client/Models/Parents/IParent.cs
@@ -1,0 +1,11 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Notion.Client
+{
+    public interface IParent
+    {
+        [JsonConverter(typeof(StringEnumConverter))]
+        ParentType Type { get; set; }
+    }
+}

--- a/Src/Notion.Client/Models/Parents/IParent.cs
+++ b/Src/Notion.Client/Models/Parents/IParent.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
 namespace Notion.Client

--- a/Src/Notion.Client/Models/Parents/PageParent.cs
+++ b/Src/Notion.Client/Models/Parents/PageParent.cs
@@ -2,7 +2,7 @@
 
 namespace Notion.Client
 {
-    public class PageParent : IPageParent
+    public class PageParent : IPageParent, IDatabaseParent
     {
         [JsonProperty("page_id")]
         public string PageId { get; set; }

--- a/Src/Notion.Client/Models/Parents/PageParent.cs
+++ b/Src/Notion.Client/Models/Parents/PageParent.cs
@@ -2,9 +2,10 @@
 
 namespace Notion.Client
 {
-    public class PageParent : Parent
+    public class PageParent : IPageParent
     {
         [JsonProperty("page_id")]
         public string PageId { get; set; }
+        public ParentType Type { get; set; }
     }
 }

--- a/Src/Notion.Client/Models/Parents/ParentType.cs
+++ b/Src/Notion.Client/Models/Parents/ParentType.cs
@@ -12,6 +12,7 @@ namespace Notion.Client
 
         [EnumMember(Value = "page_id")]
         PageId,
+
         [EnumMember(Value = "workspace")]
         Workspace
     }

--- a/Src/Notion.Client/Models/Parents/WorkspaceParent.cs
+++ b/Src/Notion.Client/Models/Parents/WorkspaceParent.cs
@@ -1,0 +1,7 @@
+﻿namespace Notion.Client
+{
+    public class WorkspaceParent : IPageParent
+    {
+        public ParentType Type { get; set; }
+    }
+}

--- a/Src/Notion.Client/Models/Parents/WorkspaceParent.cs
+++ b/Src/Notion.Client/Models/Parents/WorkspaceParent.cs
@@ -1,6 +1,6 @@
 ﻿namespace Notion.Client
 {
-    public class WorkspaceParent : IPageParent
+    public class WorkspaceParent : IPageParent, IDatabaseParent
     {
         public ParentType Type { get; set; }
     }

--- a/Test/Notion.UnitTests/DatabasesClientTests.cs
+++ b/Test/Notion.UnitTests/DatabasesClientTests.cs
@@ -62,5 +62,26 @@ namespace Notion.UnitTests
                 property.Key.Should().Be(property.Value.Name);
             }
         }
+
+        [Fact]
+        public async Task DatabasePropertyObjectContainParentProperty()
+        {
+            var databaseId = "f0212efc-caf6-4afc-87f6-1c06f1dfc8a1";
+            var path = ApiEndpoints.DatabasesApiUrls.Retrieve(databaseId);
+            var jsonData = await File.ReadAllTextAsync("data/databases/DatabasePropertyObjectContainParentProperty.json");
+
+            Server.Given(CreateGetRequestBuilder(path))
+                .RespondWith(
+                Response.Create()
+                    .WithStatusCode(200)
+                    .WithBody(jsonData)
+            );
+
+            var database = await _client.RetrieveAsync(databaseId);
+
+            database.Parent.Type.Should().Be(ParentType.PageId);
+            database.Parent.Should().BeOfType<PageParent>();
+            ((PageParent)database.Parent).PageId.Should().Be("649089db-8984-4051-98fb-a03593b852d8");
+        }
     }
 }

--- a/Test/Notion.UnitTests/Notion.UnitTests.csproj
+++ b/Test/Notion.UnitTests/Notion.UnitTests.csproj
@@ -27,6 +27,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="data\databases\DatabasePropertyObjectContainParentProperty.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="data\pages\CreatePageResponse.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/Test/Notion.UnitTests/data/databases/DatabasePropertyObjectContainParentProperty.json
+++ b/Test/Notion.UnitTests/data/databases/DatabasePropertyObjectContainParentProperty.json
@@ -1,0 +1,89 @@
+{
+  "object": "database",
+  "id": "f0212efc-caf6-4afc-87f6-1c06f1dfc8a1",
+  "created_time": "2021-05-22T18:44:00.000Z",
+  "last_edited_time": "2021-05-23T12:29:00.000Z",
+  "title": [
+    {
+      "type": "text",
+      "text": {
+        "content": "sample table",
+        "link": null
+      },
+      "annotations": {
+        "bold": false,
+        "italic": false,
+        "strikethrough": false,
+        "underline": false,
+        "code": false,
+        "color": "default"
+      },
+      "plain_text": "sample table",
+      "href": null
+    }
+  ],
+  "properties": {
+    "Tags": {
+      "id": "YG~h",
+      "name": "Tags",
+      "type": "multi_select",
+      "multi_select": {
+        "options": []
+      }
+    },
+    "SimpleText": {
+      "id": "_Dfp",
+      "name": "SimpleText",
+      "type": "rich_text",
+      "rich_text": {}
+    },
+    "Column": {
+      "id": "bxhl",
+      "name": "Column",
+      "type": "multi_select",
+      "multi_select": {
+        "options": [
+          {
+            "id": "5a44a233-33be-435e-b358-2c0ed1799dcf",
+            "name": "what",
+            "color": "gray"
+          }
+        ]
+      }
+    },
+    "SelectProp": {
+      "id": "eZ[y",
+      "name": "SelectProp",
+      "type": "select",
+      "select": {
+        "options": [
+          {
+            "id": "362dc255-c867-4543-b3ea-7bd988638228",
+            "name": "Female",
+            "color": "green"
+          }
+        ]
+      }
+    },
+    "Property": {
+      "id": "zDGa",
+      "name": "Property",
+      "type": "relation",
+      "relation": {
+        "database_id": "f86f2262-0751-40f2-8f63-e3f7a3c39fcb",
+        "synced_property_name": "Related to sample table (Property)",
+        "synced_property_id": "VQ}{"
+      }
+    },
+    "Name": {
+      "id": "title",
+      "name": "Name",
+      "type": "title",
+      "title": {}
+    }
+  },
+  "parent": {
+    "type": "page_id",
+    "page_id": "649089db-8984-4051-98fb-a03593b852d8"
+  }
+}


### PR DESCRIPTION
#58 
Database objects now return a parent property. Databases can have pages or workspaces as parents.

**Breaking Changes:**
In this PR - I've removed the Parent class and Introduced the `IParent` and `IPageParent` interfaces which help us reuse the classes for `Page Parents` and `Database Parents`.