### PR TITLE
Add support for create new databases API

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ var complexFiler = new CompoundFilter(
   - [x] Retrieve a database
   - [x] Query a database
   - [x] List databases
-  - [ ] Create a Database
+  - [x] Create a Database
 - [x] Pages
   - [x] Retrieve a page
   - [x] Create a page

--- a/Src/Notion.Client/Api/ApiEndpoints.cs
+++ b/Src/Notion.Client/Api/ApiEndpoints.cs
@@ -7,6 +7,7 @@
             public static string Retrieve(string databaseId) => $"/v1/databases/{databaseId}";
             public static string List() => "/v1/databases";
             public static string Query(string databaseId) => $"/v1/databases/{databaseId}/query";
+            public static string Create => "/v1/databases";
         }
 
         public static class UsersApiUrls

--- a/Src/Notion.Client/Api/Databases/DatabasesClient.cs
+++ b/Src/Notion.Client/Api/Databases/DatabasesClient.cs
@@ -37,5 +37,12 @@ namespace Notion.Client
 
             return await _client.PostAsync<PaginatedList<Page>>(DatabasesApiUrls.Query(databaseId), body);
         }
+
+        public async Task<Database> CreateAsync(DatabasesCreateParameters databasesCreateParameters)
+        {
+            var body = (IDatabasesCreateBodyParameters)databasesCreateParameters;
+
+            return await _client.PostAsync<Database>(DatabasesApiUrls.Create, body);
+        }
     }
 }

--- a/Src/Notion.Client/Api/Databases/IDatabasesClient.cs
+++ b/Src/Notion.Client/Api/Databases/IDatabasesClient.cs
@@ -7,5 +7,12 @@ namespace Notion.Client
         Task<Database> RetrieveAsync(string databaseId);
         Task<PaginatedList<Page>> QueryAsync(string databaseId, DatabasesQueryParameters databasesQueryParameters);
         Task<PaginatedList<Database>> ListAsync(DatabasesListParameters databasesListParameters = null);
+
+        /// <summary>
+        /// Creates a database as a subpage in the specified parent page, with the specified properties schema.
+        /// </summary>
+        /// <param name="databasesCreateParameters"></param>
+        /// <returns>Database</returns>
+        Task<Database> CreateAsync(DatabasesCreateParameters databasesCreateParameters);
     }
 }

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/DatabasesCreateParameters.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/DatabasesCreateParameters.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+namespace Notion.Client
+{
+    public class DatabasesCreateParameters : IDatabasesCreateBodyParameters, IDatabasesCreateQueryParameters
+    {
+        public ParentPageInput Parent { get; set; }
+        public Dictionary<string, IPropertySchema> Properties { get; set; }
+        public List<RichTextBaseInput> Title { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/IDatabasesCreateBodyParameters.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/IDatabasesCreateBodyParameters.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+namespace Notion.Client
+{
+    public interface IDatabasesCreateBodyParameters
+    {
+        ParentPageInput Parent { get; set; }
+        Dictionary<string, IPropertySchema> Properties { get; set; }
+        List<RichTextBaseInput> Title { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/IDatabasesCreateQueryParameters.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/IDatabasesCreateQueryParameters.cs
@@ -1,0 +1,6 @@
+﻿namespace Notion.Client
+{
+    public interface IDatabasesCreateQueryParameters
+    {
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/MentionInput.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/MentionInput.cs
@@ -1,0 +1,11 @@
+﻿namespace Notion.Client
+{
+    public class MentionInput
+    {
+        public string Type { get; set; }
+        public Person User { get; set; }
+        public ObjectId Page { get; set; }
+        public ObjectId Database { get; set; }
+        public DatePropertyValue Date { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/ParentPageInput.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/ParentPageInput.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public class ParentPageInput
+    {
+        [JsonProperty("page_id")]
+        public string PageId { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/CheckboxPropertySchema.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/CheckboxPropertySchema.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace Notion.Client
+{
+    public class CheckboxPropertySchema : IPropertySchema
+    {
+        public Dictionary<string, object> Checkbox { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/CreatedByPropertySchema.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/CreatedByPropertySchema.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public class CreatedByPropertySchema : IPropertySchema
+    {
+        [JsonProperty("created_by")]
+        public Dictionary<string, object> CreatedBy { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/CreatedTimePropertySchema.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/CreatedTimePropertySchema.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public class CreatedTimePropertySchema : IPropertySchema
+    {
+        [JsonProperty("created_time")]
+        public Dictionary<string, object> CreatedTime { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/DatePropertySchema.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/DatePropertySchema.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace Notion.Client
+{
+    public class DatePropertySchema : IPropertySchema
+    {
+        public Dictionary<string, object> Date { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/EmailPropertySchema.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/EmailPropertySchema.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace Notion.Client
+{
+    public class EmailPropertySchema : IPropertySchema
+    {
+        public Dictionary<string, object> Email { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/FilePropertySchema.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/FilePropertySchema.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace Notion.Client
+{
+    public class FilePropertySchema : IPropertySchema
+    {
+        public Dictionary<string, object> Files { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/IPropertySchema.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/IPropertySchema.cs
@@ -1,0 +1,6 @@
+﻿namespace Notion.Client
+{
+    public interface IPropertySchema
+    {
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/LastEditedByPropertySchema.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/LastEditedByPropertySchema.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public class LastEditedByPropertySchema : IPropertySchema
+    {
+        [JsonProperty("last_edited_by")]
+        public Dictionary<string, object> LastEditedBy { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/LastEditedTimePropertySchema.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/LastEditedTimePropertySchema.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public class LastEditedTimePropertySchema : IPropertySchema
+    {
+        [JsonProperty("last_edited_time")]
+        public Dictionary<string, object> LastEditedTime { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/MultiSelectOptionSchema.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/MultiSelectOptionSchema.cs
@@ -1,0 +1,6 @@
+﻿namespace Notion.Client
+{
+    public class MultiSelectOptionSchema : SelectOptionSchema
+    {
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/MultiSelectPropertySchema.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/MultiSelectPropertySchema.cs
@@ -7,8 +7,4 @@ namespace Notion.Client
         [JsonProperty("multi_select")]
         public OptionWrapper<MultiSelectOptionSchema> MultiSelect { get; set; }
     }
-
-    public class MultiSelectOptionSchema : SelectOptionSchema
-    {
-    }
 }

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/MultiSelectPropertySchema.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/MultiSelectPropertySchema.cs
@@ -1,0 +1,14 @@
+﻿using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public class MultiSelectPropertySchema : IPropertySchema
+    {
+        [JsonProperty("multi_select")]
+        public OptionWrapper<MultiSelectOptionSchema> MultiSelect { get; set; }
+    }
+
+    public class MultiSelectOptionSchema : SelectOptionSchema
+    {
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/NumberPropertySchema.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/NumberPropertySchema.cs
@@ -1,0 +1,7 @@
+﻿namespace Notion.Client
+{
+    public class NumberPropertySchema : IPropertySchema
+    {
+        public Number Number { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/PeoplePropertySchema.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/PeoplePropertySchema.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace Notion.Client
+{
+    public class PeoplePropertySchema : IPropertySchema
+    {
+        public Dictionary<string, object> People { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/PhoneNumberPropertySchema.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/PhoneNumberPropertySchema.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public class PhoneNumberPropertySchema : IPropertySchema
+    {
+        [JsonProperty("phone_number")]
+        public Dictionary<string, object> PhoneNumber { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/RichTextPropertySchema.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/RichTextPropertySchema.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public class RichTextPropertySchema : IPropertySchema
+    {
+        [JsonProperty("rich_text")]
+        public Dictionary<string, object> RichText { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/SelectOptionSchema.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/SelectOptionSchema.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Notion.Client
+{
+    public class SelectOptionSchema
+    {
+        public string Name { get; set; }
+
+        [JsonConverter(typeof(StringEnumConverter))]
+        public Color Color { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/SelectPropertySchema.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/SelectPropertySchema.cs
@@ -1,0 +1,18 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Notion.Client
+{
+    public class SelectPropertySchema : IPropertySchema
+    {
+        public OptionWrapper<SelectOptionSchema> Select { get; set; }
+    }
+
+    public class SelectOptionSchema
+    {
+        public string Name { get; set; }
+
+        [JsonConverter(typeof(StringEnumConverter))]
+        public Color Color { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/SelectPropertySchema.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/SelectPropertySchema.cs
@@ -1,18 +1,7 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-
-namespace Notion.Client
+﻿namespace Notion.Client
 {
     public class SelectPropertySchema : IPropertySchema
     {
         public OptionWrapper<SelectOptionSchema> Select { get; set; }
-    }
-
-    public class SelectOptionSchema
-    {
-        public string Name { get; set; }
-
-        [JsonConverter(typeof(StringEnumConverter))]
-        public Color Color { get; set; }
     }
 }

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/TitlePropertySchema.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/TitlePropertySchema.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace Notion.Client
+{
+    public class TitlePropertySchema : IPropertySchema
+    {
+        public Dictionary<string, object> Title { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/URLPropertyScheam.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/URLPropertyScheam.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace Notion.Client
+{
+    public class URLPropertyScheam : IPropertySchema
+    {
+        public Dictionary<string, object> Url { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/RichTextBaseInput.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/RichTextBaseInput.cs
@@ -1,0 +1,6 @@
+﻿namespace Notion.Client
+{
+    public class RichTextBaseInput : RichTextBase
+    {
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/RichTextEquationInput.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/RichTextEquationInput.cs
@@ -1,0 +1,8 @@
+﻿namespace Notion.Client
+{
+    public class RichTextEquationInput : RichTextBaseInput
+    {
+        public override RichTextType Type => RichTextType.Equation;
+        public Equation Equation { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/RichTextMentionInput.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/RichTextMentionInput.cs
@@ -1,0 +1,17 @@
+﻿namespace Notion.Client
+{
+    public class RichTextMentionInput : RichTextBaseInput
+    {
+        public override RichTextType Type => RichTextType.Mention;
+        public MentionInput Mention { get; set; }
+    }
+
+    public class MentionInput
+    {
+        public string Type { get; set; }
+        public Person User { get; set; }
+        public ObjectId Page { get; set; }
+        public ObjectId Database { get; set; }
+        public DatePropertyValue Date { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/RichTextMentionInput.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/RichTextMentionInput.cs
@@ -5,13 +5,4 @@
         public override RichTextType Type => RichTextType.Mention;
         public MentionInput Mention { get; set; }
     }
-
-    public class MentionInput
-    {
-        public string Type { get; set; }
-        public Person User { get; set; }
-        public ObjectId Page { get; set; }
-        public ObjectId Database { get; set; }
-        public DatePropertyValue Date { get; set; }
-    }
 }

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/RichTextTextInput.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/RichTextTextInput.cs
@@ -1,0 +1,8 @@
+﻿namespace Notion.Client
+{
+    public class RichTextTextInput : RichTextBaseInput
+    {
+        public override RichTextType Type => RichTextType.Text;
+        public Text Text { get; set; }
+    }
+}

--- a/Test/Notion.UnitTests/Notion.UnitTests.csproj
+++ b/Test/Notion.UnitTests/Notion.UnitTests.csproj
@@ -27,6 +27,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="data\databases\CreateDatabaseResponse.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="data\databases\DatabasePropertyObjectContainParentProperty.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/Test/Notion.UnitTests/data/databases/CreateDatabaseResponse.json
+++ b/Test/Notion.UnitTests/data/databases/CreateDatabaseResponse.json
@@ -1,0 +1,75 @@
+﻿{
+  "object": "database",
+  "id": "1e9eee34-9c5c-4fe6-a4e1-8244eb141ed8",
+  "created_time": "2021-08-18T17:39:00.000Z",
+  "last_edited_time": "2021-08-18T17:39:00.000Z",
+  "title": [
+    {
+      "type": "text",
+      "text": {
+        "content": "Grocery List",
+        "link": null
+      },
+      "annotations": {
+        "bold": false,
+        "italic": false,
+        "strikethrough": false,
+        "underline": false,
+        "code": false,
+        "color": "default"
+      },
+      "plain_text": "Grocery List",
+      "href": null
+    }
+  ],
+  "properties": {
+    "Price": {
+      "id": "@xZm",
+      "name": "Price",
+      "type": "number",
+      "number": {
+        "format": "dollar"
+      }
+    },
+    "Last ordered": {
+      "id": "SN;?",
+      "name": "Last ordered",
+      "type": "date",
+      "date": {}
+    },
+    "Food group": {
+      "id": "zIZQ",
+      "name": "Food group",
+      "type": "select",
+      "select": {
+        "options": [
+          {
+            "id": "49ca815e-c37a-4dce-9033-32a62233f483",
+            "name": "🥦Vegetable",
+            "color": "green"
+          },
+          {
+            "id": "9fa8d118-59fb-47c7-b4c7-a8523609e37f",
+            "name": "🍎Fruit",
+            "color": "red"
+          },
+          {
+            "id": "ef3c69d2-0cd1-4540-82fd-03ff9650fc44",
+            "name": "💪Protein",
+            "color": "yellow"
+          }
+        ]
+      }
+    },
+    "Name": {
+      "id": "title",
+      "name": "Name",
+      "type": "title",
+      "title": {}
+    }
+  },
+  "parent": {
+    "type": "page_id",
+    "page_id": "533578e3-edf1-4c0a-91a9-da6b09bac3ee"
+  }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -67,7 +67,7 @@ var complexFiler = new CompoundFilter(
   - [x] Retrieve a database
   - [x] Query a database
   - [x] List databases
-  - [ ] Create a Database
+  - [x] Create a Database
 - [x] Pages
   - [x] Retrieve a page
   - [x] Create a page


### PR DESCRIPTION
## Description

You can now use the Notion API to create a database as a subpage of an existing page.

Currently supported property types are `title`, `rich_text`, `number`, `select`. `multi_select`, `date`, `people`, `files`, `checkbox`, `url`, `email`, `phone_number`, `created_time`, `created_by`, `last_edited_time`, `last_edited_by`.

Fixes # (issue)
#56 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
