### PR TITLE
Add support for update database API

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,12 @@ var complexFiler = new CompoundFilter(
 ```
 
 ## Supported Endpoints
-- [ ] Databases
+- [x] Databases
   - [x] Retrieve a database
   - [x] Query a database
   - [x] List databases
-  - [x] Create a Database
+  - [x] Create a database
+  - [x] Update database
 - [x] Pages
   - [x] Retrieve a page
   - [x] Create a page

--- a/Src/Notion.Client/Api/ApiEndpoints.cs
+++ b/Src/Notion.Client/Api/ApiEndpoints.cs
@@ -8,6 +8,7 @@
             public static string List() => "/v1/databases";
             public static string Query(string databaseId) => $"/v1/databases/{databaseId}/query";
             public static string Create => "/v1/databases";
+            public static string Update(string databaseId) => $"/v1/databases/{databaseId}";
         }
 
         public static class UsersApiUrls

--- a/Src/Notion.Client/Api/Databases/DatabasesClient.cs
+++ b/Src/Notion.Client/Api/Databases/DatabasesClient.cs
@@ -44,5 +44,12 @@ namespace Notion.Client
 
             return await _client.PostAsync<Database>(DatabasesApiUrls.Create, body);
         }
+
+        public async Task<Database> UpdateAsync(string databaseId, DatabasesUpdateParameters databasesUpdateParameters)
+        {
+            var body = (IDatabasesUpdateBodyParameters)databasesUpdateParameters;
+
+            return await _client.PatchAsync<Database>(DatabasesApiUrls.Update(databaseId), body);
+        }
     }
 }

--- a/Src/Notion.Client/Api/Databases/IDatabasesClient.cs
+++ b/Src/Notion.Client/Api/Databases/IDatabasesClient.cs
@@ -14,5 +14,13 @@ namespace Notion.Client
         /// <param name="databasesCreateParameters"></param>
         /// <returns>Database</returns>
         Task<Database> CreateAsync(DatabasesCreateParameters databasesCreateParameters);
+
+        /// <summary>
+        /// Updates an existing database as specified by the parameters.
+        /// </summary>
+        /// <param name="databaseId"></param>
+        /// <param name="databasesUpdateParameters"></param>
+        /// <returns>Database</returns>
+        Task<Database> UpdateAsync(string databaseId, DatabasesUpdateParameters databasesUpdateParameters);
     }
 }

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/DatabasesUpdateParameters.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/DatabasesUpdateParameters.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+
+namespace Notion.Client
+{
+    public interface IDatabasesUpdateBodyParameters
+    {
+        Dictionary<string, IUpdatePropertySchema> Properties { get; set; }
+        List<RichTextBaseInput> Title { get; set; }
+    }
+
+    public class DatabasesUpdateParameters : IDatabasesUpdateBodyParameters
+    {
+        public Dictionary<string, IUpdatePropertySchema> Properties { get; set; }
+        public List<RichTextBaseInput> Title { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/PropertySchema/CheckboxUpdatePropertySchema.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/PropertySchema/CheckboxUpdatePropertySchema.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace Notion.Client
+{
+    public class CheckboxUpdatePropertySchema : IUpdatePropertySchema
+    {
+        public Dictionary<string, object> Checkbox { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/PropertySchema/CreatedByUpdatePropertySchema.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/PropertySchema/CreatedByUpdatePropertySchema.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public class CreatedByUpdatePropertySchema : IUpdatePropertySchema
+    {
+        [JsonProperty("created_by")]
+        public Dictionary<string, object> CreatedBy { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/PropertySchema/CreatedTimeUpdatePropertySchema.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/PropertySchema/CreatedTimeUpdatePropertySchema.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public class CreatedTimeUpdatePropertySchema : IUpdatePropertySchema
+    {
+        [JsonProperty("created_time")]
+        public Dictionary<string, object> CreatedTime { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/PropertySchema/DateUpdatePropertySchema.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/PropertySchema/DateUpdatePropertySchema.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace Notion.Client
+{
+    public class DateUpdatePropertySchema : IUpdatePropertySchema
+    {
+        public Dictionary<string, object> Date { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/PropertySchema/EmailUpdatePropertySchema.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/PropertySchema/EmailUpdatePropertySchema.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace Notion.Client
+{
+    public class EmailUpdatePropertySchema : IUpdatePropertySchema
+    {
+        public Dictionary<string, object> Email { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/PropertySchema/FilesUpdatePropertySchema.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/PropertySchema/FilesUpdatePropertySchema.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace Notion.Client
+{
+    public class FilesUpdatePropertySchema : IUpdatePropertySchema
+    {
+        public Dictionary<string, object> File { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/PropertySchema/IUpdatePropertySchema.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/PropertySchema/IUpdatePropertySchema.cs
@@ -1,0 +1,6 @@
+﻿namespace Notion.Client
+{
+    public interface IUpdatePropertySchema
+    {
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/PropertySchema/LastEditedByUpdatePropertySchema.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/PropertySchema/LastEditedByUpdatePropertySchema.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public class LastEditedByUpdatePropertySchema : IUpdatePropertySchema
+    {
+        [JsonProperty("last_edited_by")]
+        public Dictionary<string, object> LastEditedBy { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/PropertySchema/LastEditedTimeUpdatePropertySchema.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/PropertySchema/LastEditedTimeUpdatePropertySchema.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public class LastEditedTimeUpdatePropertySchema : IUpdatePropertySchema
+    {
+        [JsonProperty("last_edited_time")]
+        public Dictionary<string, object> LastEditedTime { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/PropertySchema/MultiSelectUpdatePropertySchema.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/PropertySchema/MultiSelectUpdatePropertySchema.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public class MultiSelectUpdatePropertySchema : IUpdatePropertySchema
+    {
+        [JsonProperty("multi_select")]
+        public OptionWrapper<SelectOption> MultiSelect { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/PropertySchema/NumberUpdatePropertySchema.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/PropertySchema/NumberUpdatePropertySchema.cs
@@ -1,0 +1,7 @@
+﻿namespace Notion.Client
+{
+    public class NumberUpdatePropertySchema : IUpdatePropertySchema
+    {
+        public Number Number { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/PropertySchema/PeopleUpdatePropertySchema.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/PropertySchema/PeopleUpdatePropertySchema.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace Notion.Client
+{
+    public class PeopleUpdatePropertySchema : IUpdatePropertySchema
+    {
+        public Dictionary<string, object> People { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/PropertySchema/PhoneNumberUpdatePropertySchema.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/PropertySchema/PhoneNumberUpdatePropertySchema.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public class PhoneNumberUpdatePropertySchema : IUpdatePropertySchema
+    {
+        [JsonProperty("phone_number")]
+        public Dictionary<string, object> PhoneNumber { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/PropertySchema/RichTextUpdatePropertySchema.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/PropertySchema/RichTextUpdatePropertySchema.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public class RichTextUpdatePropertySchema : IUpdatePropertySchema
+    {
+        [JsonProperty("rich_text")]
+        public Dictionary<string, object> RichText { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/PropertySchema/SelectUpdatePropertySchema.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/PropertySchema/SelectUpdatePropertySchema.cs
@@ -1,15 +1,7 @@
-﻿using Newtonsoft.Json;
-
-namespace Notion.Client
+﻿namespace Notion.Client
 {
     public class SelectUpdatePropertySchema : IUpdatePropertySchema
     {
         public OptionWrapper<SelectOption> Select { get; set; }
-    }
-
-    public class MultiSelectUpdatePropertySchema : IUpdatePropertySchema
-    {
-        [JsonProperty("multi_select")]
-        public OptionWrapper<SelectOption> MultiSelect { get; set; }
     }
 }

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/PropertySchema/SelectUpdatePropertySchema.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/PropertySchema/SelectUpdatePropertySchema.cs
@@ -1,0 +1,15 @@
+﻿using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public class SelectUpdatePropertySchema : IUpdatePropertySchema
+    {
+        public OptionWrapper<SelectOption> Select { get; set; }
+    }
+
+    public class MultiSelectUpdatePropertySchema : IUpdatePropertySchema
+    {
+        [JsonProperty("multi_select")]
+        public OptionWrapper<SelectOption> MultiSelect { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/PropertySchema/TitleUpdatePropertySchema.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/PropertySchema/TitleUpdatePropertySchema.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace Notion.Client
+{
+    public class TitleUpdatePropertySchema : IUpdatePropertySchema
+    {
+        public Dictionary<string, object> Title { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/PropertySchema/URLUpdatePropertySchema.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/PropertySchema/URLUpdatePropertySchema.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace Notion.Client
+{
+    public class URLUpdatePropertySchema : IUpdatePropertySchema
+    {
+        public Dictionary<string, object> Url { get; set; }
+    }
+}

--- a/Test/Notion.UnitTests/DatabasesClientTests.cs
+++ b/Test/Notion.UnitTests/DatabasesClientTests.cs
@@ -255,5 +255,108 @@ namespace Notion.UnitTests
                 }
             );
         }
+
+        [Fact]
+        public async Task UpdateDatabaseAsync()
+        {
+            var databaseId = "1e9eee34-9c5c-4fe6-a4e1-8244eb141ed8";
+            var path = ApiEndpoints.DatabasesApiUrls.Update(databaseId);
+            var jsonData = await File.ReadAllTextAsync("data/databases/UpdateDatabaseResponse.json");
+
+            Server.Given(CreatePatchRequestBuilder(path))
+                .RespondWith(
+                Response.Create()
+                    .WithStatusCode(200)
+                    .WithBody(jsonData)
+            );
+
+            var updateDatabaseParameters = new DatabasesUpdateParameters();
+
+            updateDatabaseParameters.Title = new List<RichTextBaseInput>
+            {
+                new RichTextTextInput
+                {
+                    Text = new Text
+                    {
+                        Content = "Grocery List New",
+                        Link = null
+                    }
+                }
+            };
+
+            updateDatabaseParameters.Properties = new Dictionary<string, IUpdatePropertySchema>
+            {
+                { "Name", new TitleUpdatePropertySchema { Title = new Dictionary<string, object>() } },
+                { "Price", new NumberUpdatePropertySchema { Number = new Number { Format = NumberFormat.Yen } } },
+                { "Food group", new SelectUpdatePropertySchema
+                    {
+                        Select = new OptionWrapper<SelectOption>
+                        {
+                            Options = new List<SelectOption>
+                            {
+                                new SelectOption
+                                {
+                                    Color = Color.Green,
+                                    Name = "🥦Vegetables"
+                                },
+                                new SelectOption
+                                {
+                                    Color = Color.Red,
+                                    Name = "🍎Fruit"
+                                },
+                                new SelectOption
+                                {
+                                    Color = Color.Yellow,
+                                    Name = "💪Protein"
+                                }
+                            }
+                        }
+                    }
+                },
+                { "Last ordered", new DateUpdatePropertySchema{ Date = new Dictionary<string, object>() } }
+            };
+
+            var database = await _client.UpdateAsync(databaseId, updateDatabaseParameters);
+
+            database.Parent.Type.Should().Be(ParentType.PageId);
+            database.Parent.Should().BeOfType<PageParent>();
+            ((PageParent)database.Parent).PageId.Should().Be("533578e3-edf1-4c0a-91a9-da6b09bac3ee");
+
+            database.Properties.Should().HaveCount(4);
+
+
+            database.Title.Should().ContainSingle();
+            database.Title.Should().SatisfyRespectively(
+                title =>
+                {
+                    title.Should().BeAssignableTo<RichTextText>();
+                    ((RichTextText)title).Text.Content.Should().Be("Grocery List New");
+                }
+            );
+
+
+            var selectOptions = (SelectProperty)database.Properties["Food group"];
+            selectOptions.Name.Should().Be("Food group");
+            selectOptions.Select.Options.Should().SatisfyRespectively(
+                option =>
+                {
+                    option.Name.Should().Be("🥦Vegetables");
+                    option.Color.Should().Be(Color.Green);
+                },
+                option =>
+                {
+                    option.Name.Should().Be("🍎Fruit");
+                    option.Color.Should().Be(Color.Red);
+                },
+                option =>
+                {
+                    option.Name.Should().Be("💪Protein");
+                    option.Color.Should().Be(Color.Yellow);
+                }
+            );
+
+            var price = (NumberProperty)database.Properties["Price"];
+            price.Number.Format.Should().Be(NumberFormat.Yen);
+        }
     }
 }

--- a/Test/Notion.UnitTests/DatabasesClientTests.cs
+++ b/Test/Notion.UnitTests/DatabasesClientTests.cs
@@ -324,7 +324,6 @@ namespace Notion.UnitTests
 
             database.Properties.Should().HaveCount(4);
 
-
             database.Title.Should().ContainSingle();
             database.Title.Should().SatisfyRespectively(
                 title =>
@@ -333,7 +332,6 @@ namespace Notion.UnitTests
                     ((RichTextText)title).Text.Content.Should().Be("Grocery List New");
                 }
             );
-
 
             var selectOptions = (SelectProperty)database.Properties["Food group"];
             selectOptions.Name.Should().Be("Food group");

--- a/Test/Notion.UnitTests/Notion.UnitTests.csproj
+++ b/Test/Notion.UnitTests/Notion.UnitTests.csproj
@@ -33,6 +33,9 @@
     <None Update="data\databases\DatabasePropertyObjectContainParentProperty.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="data\databases\UpdateDatabaseResponse.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="data\pages\CreatePageResponse.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/Test/Notion.UnitTests/data/databases/UpdateDatabaseResponse.json
+++ b/Test/Notion.UnitTests/data/databases/UpdateDatabaseResponse.json
@@ -1,0 +1,75 @@
+﻿{
+  "object": "database",
+  "id": "1e9eee34-9c5c-4fe6-a4e1-8244eb141ed8",
+  "created_time": "2021-08-18T17:39:00.000Z",
+  "last_edited_time": "2021-08-18T20:00:00.000Z",
+  "title": [
+    {
+      "type": "text",
+      "text": {
+        "content": "Grocery List New",
+        "link": null
+      },
+      "annotations": {
+        "bold": false,
+        "italic": false,
+        "strikethrough": false,
+        "underline": false,
+        "code": false,
+        "color": "default"
+      },
+      "plain_text": "Grocery List New",
+      "href": null
+    }
+  ],
+  "properties": {
+    "Price": {
+      "id": "@xZm",
+      "name": "Price",
+      "type": "number",
+      "number": {
+        "format": "yen"
+      }
+    },
+    "Last ordered": {
+      "id": "SN;?",
+      "name": "Last ordered",
+      "type": "date",
+      "date": {}
+    },
+    "Food group": {
+      "id": "zIZQ",
+      "name": "Food group",
+      "type": "select",
+      "select": {
+        "options": [
+          {
+            "id": "58c5640a-d34d-4d11-9ce4-2dcd279fa9b7",
+            "name": "🥦Vegetables",
+            "color": "green"
+          },
+          {
+            "id": "3ac2b777-180e-4f45-aa3f-5d49a5bd4344",
+            "name": "🍎Fruit",
+            "color": "red"
+          },
+          {
+            "id": "f0b31ad9-a33b-491c-aeb5-15dffb40dae7",
+            "name": "💪Protein",
+            "color": "yellow"
+          }
+        ]
+      }
+    },
+    "Name": {
+      "id": "title",
+      "name": "Name",
+      "type": "title",
+      "title": {}
+    }
+  },
+  "parent": {
+    "type": "page_id",
+    "page_id": "533578e3-edf1-4c0a-91a9-da6b09bac3ee"
+  }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -63,11 +63,12 @@ var complexFiler = new CompoundFilter(
 
 ## Supported Endpoints
 
-- [ ] Databases
+- [x] Databases
   - [x] Retrieve a database
   - [x] Query a database
   - [x] List databases
-  - [x] Create a Database
+  - [x] Create a database
+  - [x] Update database
 - [x] Pages
   - [x] Retrieve a page
   - [x] Create a page


### PR DESCRIPTION
## Description

You can now use the Notion API to update databases!

Supported updates are:

- renaming the database
- adding and removing properties
- renaming properties
- updating property types.

Note that updating the name and color select and multi select options is not supported.

Fixes # (issue)
#80 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
