### PR TITLE
Append block children returns a list of blocks ✨

### DIFF
--- a/Src/Notion.Client/Api/Blocks/BlocksClient.cs
+++ b/Src/Notion.Client/Api/Blocks/BlocksClient.cs
@@ -34,7 +34,7 @@ namespace Notion.Client
             return await _client.GetAsync<PaginatedList<Block>>(url, queryParams);
         }
 
-        public async Task<Block> AppendChildrenAsync(string blockId, BlocksAppendChildrenParameters parameters = null)
+        public async Task<PaginatedList<Block>> AppendChildrenAsync(string blockId, BlocksAppendChildrenParameters parameters = null)
         {
             if (string.IsNullOrWhiteSpace(blockId))
             {
@@ -45,7 +45,7 @@ namespace Notion.Client
 
             var body = (IBlocksAppendChildrenBodyParameters)parameters;
 
-            return await _client.PatchAsync<Block>(url, body);
+            return await _client.PatchAsync<PaginatedList<Block>>(url, body);
         }
 
         public async Task<Block> RetrieveAsync(string blockId)

--- a/Src/Notion.Client/Api/Blocks/IBlocksClient.cs
+++ b/Src/Notion.Client/Api/Blocks/IBlocksClient.cs
@@ -20,6 +20,13 @@ namespace Notion.Client
         Task<Block> UpdateAsync(string blockId, IUpdateBlock updateBlock);
 
         Task<PaginatedList<Block>> RetrieveChildrenAsync(string blockId, BlocksRetrieveChildrenParameters parameters = null);
-        Task<Block> AppendChildrenAsync(string blockId, BlocksAppendChildrenParameters parameters = null);
+
+        /// <summary>
+        /// Creates and appends new children blocks to the parent block_id specified.
+        /// </summary>
+        /// <param name="blockId">Identifier for a block</param>
+        /// <param name="parameters"></param>
+        /// <returns>A paginated list of newly created first level children block objects.</returns>
+        Task<PaginatedList<Block>> AppendChildrenAsync(string blockId, BlocksAppendChildrenParameters parameters = null);
     }
 }

--- a/Src/Notion.Client/Constants.cs
+++ b/Src/Notion.Client/Constants.cs
@@ -6,6 +6,6 @@ namespace Notion.Client
     internal class Constants
     {
         internal static string BASE_URL = "https://api.notion.com/";
-        internal static string DEFAULT_NOTION_VERSION = "2021-05-13";
+        internal static string DEFAULT_NOTION_VERSION = "2021-08-16";
     }
 }

--- a/Test/Notion.UnitTests/BlocksClientTests.cs
+++ b/Test/Notion.UnitTests/BlocksClientTests.cs
@@ -101,14 +101,27 @@ namespace Notion.UnitTests
             };
 
             // Act
-            var block = await _client.AppendChildrenAsync(blockId, parameters);
+            var blocksResult = await _client.AppendChildrenAsync(blockId, parameters);
 
-            // Assert    
-            block.Type.Should().Be(BlockType.Paragraph);
-            var paragraphBlock = (ParagraphBlock)block;
-            var text = paragraphBlock.Paragraph.Text.OfType<RichTextText>().LastOrDefault();
-            text.Text.Content.Should().Be("Lacinato kale is a variety of kale with a long tradition in Italian cuisine, especially that of Tuscany. It is also known as Tuscan kale, Italian kale, dinosaur kale, kale, flat back kale, palm tree kale, or black Tuscan palm.");
-            text.Text.Link.Url.Should().Be("https://en.wikipedia.org/wiki/Lacinato_kale");
+            // Assert
+            var blocks = blocksResult.Results;
+            blocks.Should().SatisfyRespectively(
+                block =>
+                {
+                    block.Type.Should().Be(BlockType.Heading_2);
+                    var headingBlock = (HeadingTwoBlock)block;
+                    var text = headingBlock.Heading_2.Text.OfType<RichTextText>().FirstOrDefault();
+                    text.Text.Content.Should().Be("Lacinato kale");
+                },
+                block =>
+                {
+                    block.Type.Should().Be(BlockType.Paragraph);
+                    var paragraphBlock = (ParagraphBlock)block;
+                    var text = paragraphBlock.Paragraph.Text.OfType<RichTextText>().LastOrDefault();
+                    text.Text.Content.Should().Be("Lacinato kale is a variety of kale with a long tradition in Italian cuisine, especially that of Tuscany. It is also known as Tuscan kale, Italian kale, dinosaur kale, kale, flat back kale, palm tree kale, or black Tuscan palm.");
+                    text.Text.Link.Url.Should().Be("https://en.wikipedia.org/wiki/Lacinato_kale");
+                }
+            );
         }
 
         [Fact]

--- a/Test/Notion.UnitTests/data/blocks/AppendBlockChildrenResponse.json
+++ b/Test/Notion.UnitTests/data/blocks/AppendBlockChildrenResponse.json
@@ -1,50 +1,86 @@
 {
-  "object": "block",
-  "id": "7face6fd-3ef4-4b38-b1dc-c5044988eec0",
-  "created_time": "2021-03-16T16:34:00.000Z",
-  "last_edited_time": "2021-03-16T16:36:00.000Z",
-  "has_children": false,
-  "type": "paragraph",
-  "paragraph": {
-    "text": [
-      {
-        "type": "text",
-        "text": {
-          "content": "Lacinato kale",
-          "link": {
-            "url": "https://en.wikipedia.org/wiki/Lacinato_kale"
+  "object": "list",
+  "results": [
+    {
+      "object": "block",
+      "id": "9bc30ad4-9373-46a5-84ab-0a7845ee52e6",
+      "created_time": "2021-03-16T16:31:00.000Z",
+      "last_edited_time": "2021-03-16T16:32:00.000Z",
+      "has_children": false,
+      "type": "heading_2",
+      "heading_2": {
+        "text": [
+          {
+            "type": "text",
+            "text": {
+              "content": "Lacinato kale",
+              "link": null
+            },
+            "annotations": {
+              "bold": false,
+              "italic": false,
+              "strikethrough": false,
+              "underline": false,
+              "code": false,
+              "color": "default"
+            },
+            "plain_text": "Lacinato kale",
+            "href": null
           }
-        },
-        "annotations": {
-          "bold": false,
-          "italic": false,
-          "strikethrough": false,
-          "underline": false,
-          "code": false,
-          "color": "default"
-        },
-        "plain_text": "Lacinato kale",
-        "href": "https://en.wikipedia.org/wiki/Lacinato_kale"
-      },
-      {
-        "type": "text",
-        "text": {
-          "content": "Lacinato kale is a variety of kale with a long tradition in Italian cuisine, especially that of Tuscany. It is also known as Tuscan kale, Italian kale, dinosaur kale, kale, flat back kale, palm tree kale, or black Tuscan palm.",
-          "link": {
-            "url": "https://en.wikipedia.org/wiki/Lacinato_kale"
-          }
-        },
-        "annotations": {
-          "bold": false,
-          "italic": false,
-          "strikethrough": false,
-          "underline": false,
-          "code": false,
-          "color": "default"
-        },
-        "plain_text": "Lacinato kale is a variety of kale with a long tradition in Italian cuisine, especially that of Tuscany. It is also known as Tuscan kale, Italian kale, dinosaur kale, kale, flat back kale, palm tree kale, or black Tuscan palm.",
-        "href": "https://en.wikipedia.org/wiki/Lacinato_kale"
+        ]
       }
-    ]
-  }
+    },
+    {
+      "object": "block",
+      "id": "7face6fd-3ef4-4b38-b1dc-c5044988eec0",
+      "created_time": "2021-03-16T16:34:00.000Z",
+      "last_edited_time": "2021-03-16T16:36:00.000Z",
+      "has_children": false,
+      "type": "paragraph",
+      "paragraph": {
+        "text": [
+          {
+            "type": "text",
+            "text": {
+              "content": "Lacinato kale",
+              "link": {
+                "url": "https://en.wikipedia.org/wiki/Lacinato_kale"
+              }
+            },
+            "annotations": {
+              "bold": false,
+              "italic": false,
+              "strikethrough": false,
+              "underline": false,
+              "code": false,
+              "color": "default"
+            },
+            "plain_text": "Lacinato kale",
+            "href": "https://en.wikipedia.org/wiki/Lacinato_kale"
+          },
+          {
+            "type": "text",
+            "text": {
+              "content": "Lacinato kale is a variety of kale with a long tradition in Italian cuisine, especially that of Tuscany. It is also known as Tuscan kale, Italian kale, dinosaur kale, kale, flat back kale, palm tree kale, or black Tuscan palm.",
+              "link": {
+                "url": "https://en.wikipedia.org/wiki/Lacinato_kale"
+              }
+            },
+            "annotations": {
+              "bold": false,
+              "italic": false,
+              "strikethrough": false,
+              "underline": false,
+              "code": false,
+              "color": "default"
+            },
+            "plain_text": "Lacinato kale is a variety of kale with a long tradition in Italian cuisine, especially that of Tuscany. It is also known as Tuscan kale, Italian kale, dinosaur kale, kale, flat back kale, palm tree kale, or black Tuscan palm.",
+            "href": "https://en.wikipedia.org/wiki/Lacinato_kale"
+          }
+        ]
+      }
+    }
+  ],
+  "next_cursor": null,
+  "has_more": false
 }


### PR DESCRIPTION
## Description
The Append Block Children endpoint will now return a list of the newly created Block object children.
Previously the endpoint returned the block object of the parent block.

Fixes # (issue)
#127 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
