### PR TITLE
Add support for link_to_page block type

### DIFF
--- a/Src/Notion.Client/Api/Blocks/RequestParams/BlocksUpdateParameters/UpdateBlocks/LinkToPageUpdateBlock.cs
+++ b/Src/Notion.Client/Api/Blocks/RequestParams/BlocksUpdateParameters/UpdateBlocks/LinkToPageUpdateBlock.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public class LinkToPageUpdateBlock : UpdateBlock, IUpdateBlock
+    {
+        [JsonProperty("link_to_page")]
+        public IPageParentInput LinkToPage { get; set; }
+    }
+}

--- a/Src/Notion.Client/Models/Blocks/BlockType.cs
+++ b/Src/Notion.Client/Models/Blocks/BlockType.cs
@@ -85,6 +85,9 @@ namespace Notion.Client
         [EnumMember(Value = "template")]
         Template,
 
+        [EnumMember(Value = "link_to_page")]
+        LinkToPage,
+
         [EnumMember(Value = "unsupported")]
         Unsupported
     }

--- a/Src/Notion.Client/Models/Blocks/IBlock.cs
+++ b/Src/Notion.Client/Models/Blocks/IBlock.cs
@@ -23,6 +23,7 @@ namespace Notion.Client
     [JsonSubtypes.KnownSubType(typeof(HeadingTwoBlock), BlockType.Heading_2)]
     [JsonSubtypes.KnownSubType(typeof(HeadingThreeeBlock), BlockType.Heading_3)]
     [JsonSubtypes.KnownSubType(typeof(ImageBlock), BlockType.Image)]
+    [JsonSubtypes.KnownSubType(typeof(LinkToPageBlock), BlockType.LinkToPage)]
     [JsonSubtypes.KnownSubType(typeof(NumberedListItemBlock), BlockType.NumberedListItem)]
     [JsonSubtypes.KnownSubType(typeof(ParagraphBlock), BlockType.Paragraph)]
     [JsonSubtypes.KnownSubType(typeof(PDFBlock), BlockType.PDF)]

--- a/Src/Notion.Client/Models/Blocks/LinkToPageBlock.cs
+++ b/Src/Notion.Client/Models/Blocks/LinkToPageBlock.cs
@@ -1,0 +1,12 @@
+﻿using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public class LinkToPageBlock : Block, IColumnChildrenBlock, INonColumnBlock
+    {
+        public override BlockType Type => BlockType.LinkToPage;
+
+        [JsonProperty("link_to_page")]
+        public IPageParent LinkToPage { get; set; }
+    }
+}

--- a/Test/Notion.IntegrationTests/IBlocksClientTests.cs
+++ b/Test/Notion.IntegrationTests/IBlocksClientTests.cs
@@ -506,6 +506,35 @@ namespace Notion.IntegrationTests
                         Assert.Null(templateBlock.Template.Children);
                         Assert.Equal("Test Template 2", templateBlock.Template.Text.OfType<RichTextText>().First().Text.Content);
                     })
+                },
+                new object[]
+                {
+                    new LinkToPageBlock()
+                    {
+                        LinkToPage = new PageParent
+                        {
+                            Type =  ParentType.PageId,
+                            PageId = "533578e3edf14c0a91a9da6b09bac3ee"
+                        }
+                    },
+                    new LinkToPageUpdateBlock()
+                    {
+                        LinkToPage = new ParentPageInput
+                        {
+                            PageId = "3c357473a28149a488c010d2b245a589"
+                        }
+                    },
+                    new Action<IBlock>(block =>
+                    {
+                        Assert.NotNull(block);
+                        var linkToPageBlock = Assert.IsType<LinkToPageBlock>(block);
+
+                        var pageParent = Assert.IsType<PageParent>(linkToPageBlock.LinkToPage);
+
+                        // TODO: Currently the api doesn't allow to update the link_to_page block type
+                        // This will change to updated ID once api start to support
+                        Assert.Equal(Guid.Parse("533578e3edf14c0a91a9da6b09bac3ee"), Guid.Parse(pageParent.PageId));
+                    })
                 }
             };
         }


### PR DESCRIPTION
## Description

Adds support for link to page block type.

Fixes # (issue)
#209 
## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
