### PR TITLE
237 - Add ability to clear date property

### DIFF
--- a/Src/Notion.Client/Models/PropertyValue/DatePropertyValue.cs
+++ b/Src/Notion.Client/Models/PropertyValue/DatePropertyValue.cs
@@ -13,8 +13,8 @@ namespace Notion.Client
         /// <summary>
         /// Date
         /// </summary>
-        [JsonProperty("date")]
-        public Date Date { get; set; }
+        [JsonProperty("date", NullValueHandling = NullValueHandling.Include)]
+        public Date? Date { get; set; }
     }
 
     /// <summary>

--- a/Src/Notion.Client/Notion.Client.csproj
+++ b/Src/Notion.Client/Notion.Client.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <VersionPrefix>2.2.3-preview</VersionPrefix>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     
     <PackageId>Notion.Net</PackageId>
     <Authors>Vedant Koditkar</Authors>

--- a/Test/Notion.IntegrationTests/IPageClientTests.cs
+++ b/Test/Notion.IntegrationTests/IPageClientTests.cs
@@ -201,7 +201,7 @@ namespace Notion.IntegrationTests
             var page = await _client.Pages.CreateAsync(pagesCreateParameters);
 
             page.Properties.TryGetValue(datePropertyName, out var tester);
-            DatePropertyValue setDate = (DatePropertyValue) tester;
+            DatePropertyValue setDate = (DatePropertyValue)tester;
             setDate?.Date?.Start.Should().Be(Convert.ToDateTime("2020-12-08T12:00:00Z"));
 
             // verify


### PR DESCRIPTION
Updated c# from 7.3 to 8 for nullable reference type support

## Description

Add ability to clear date property
    
   Made Date Property nullable in DatePropertyValue.cs
   Nullable reference type is supported from C# 8.0, so bumped it.
   Didn't make DatePropertyItem.cs date property nullable as it was just used for retrieval

Fixes # (issue)
#237 

## Type of change

#237 - Added Feature

- [x] Feature 

## How Has This Been Tested?

#237 - Tested the library by Updating the page of a database & also compared the request body sent by library with the official api postman collection.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

