### PR TITLE
Added Table & TableRow Support for AppendBlockChildren, RetrieveBlock…

### DIFF
--- a/Src/Notion.Client/Api/Blocks/RequestParams/BlocksUpdateParameters/UpdateBlocks/TableRowUpdateBlock.cs
+++ b/Src/Notion.Client/Api/Blocks/RequestParams/BlocksUpdateParameters/UpdateBlocks/TableRowUpdateBlock.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public class TableRowUpdateBlock : UpdateBlock, IUpdateBlock
+    {
+        [JsonProperty("table_row")]
+        public Info TableRow { get; set; }
+
+        public class Info
+        {
+            [JsonProperty("cells")]
+            public TextContentUpdate Cells { get; set; }
+        }
+    }
+}

--- a/Src/Notion.Client/Api/Blocks/RequestParams/BlocksUpdateParameters/UpdateBlocks/TableUpdateBlock.cs
+++ b/Src/Notion.Client/Api/Blocks/RequestParams/BlocksUpdateParameters/UpdateBlocks/TableUpdateBlock.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public class TableUpdateBlock : UpdateBlock, IUpdateBlock
+    {
+        [JsonProperty("table")]
+        public Info Table { get; set; }
+
+        public class Info
+        {
+            [JsonProperty("has_column_header")]
+            public bool HasColumnHeader { get; set; }
+
+            [JsonProperty("has_row_header")]
+            public bool HasRowHeader { get; set; }
+        }
+    }
+}

--- a/Src/Notion.Client/Models/Blocks/BlockType.cs
+++ b/Src/Notion.Client/Models/Blocks/BlockType.cs
@@ -92,6 +92,12 @@ namespace Notion.Client
         SyncedBlock,
 
         [EnumMember(Value = "unsupported")]
-        Unsupported
+        Unsupported,
+
+        [EnumMember(Value = "table")]
+        Table,
+
+        [EnumMember(Value = "table_row")]
+        TableRow
     }
 }

--- a/Src/Notion.Client/Models/Blocks/IBlock.cs
+++ b/Src/Notion.Client/Models/Blocks/IBlock.cs
@@ -34,6 +34,8 @@ namespace Notion.Client
     [JsonSubtypes.KnownSubType(typeof(ToggleBlock), BlockType.Toggle)]
     [JsonSubtypes.KnownSubType(typeof(VideoBlock), BlockType.Video)]
     [JsonSubtypes.KnownSubType(typeof(UnsupportedBlock), BlockType.Unsupported)]
+    [JsonSubtypes.KnownSubType(typeof(TableBlock), BlockType.Table)]
+    [JsonSubtypes.KnownSubType(typeof(TableRowBlock), BlockType.TableRow)]
     public interface IBlock : IObject
     {
         [JsonProperty("type")]

--- a/Src/Notion.Client/Models/Blocks/TableBlock.cs
+++ b/Src/Notion.Client/Models/Blocks/TableBlock.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    internal class TableBlock : Block
+    {
+        public override BlockType Type => BlockType.Table;
+
+        [JsonProperty("table")]
+        public Info Table { get; set; }
+
+        public class Info
+        {
+            [JsonProperty("table_width")]
+            public int TableWidth { get; set; }
+
+            [JsonProperty("has_column_header")]
+            public bool HasColumnHeader { get; set; }
+
+            [JsonProperty("has_row_header")]
+            public bool HasRowHeader { get; set; }
+
+            [JsonProperty("children")]
+            public TableRowBlock Children { get; set; }
+        }
+    }
+}

--- a/Src/Notion.Client/Models/Blocks/TableRowBlock.cs
+++ b/Src/Notion.Client/Models/Blocks/TableRowBlock.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public class TableRowBlock : Block
+    {
+        public override BlockType Type => BlockType.TableRow;
+
+        [JsonProperty("table_row")]
+        public Info TableRow { get; set; }
+
+        public class Info
+        {
+            [JsonProperty("cells")]
+            public IEnumerable<IEnumerable<RichTextText>> Cells { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
Added Table Support.

## Description

Added Model classes for Table & TableRow Block Types.
Supported Table & TableRow Block Operations:
1. Add Children to an existing table
2. Get Table Data
3. Get TableRows Data

Fixes # (issue)

#226 - Add Table Support

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

#226 - Compared the request body & response body sent by library with the official api postman collection for AppendBlockChildren & RetrieveBlockChildren
Added Integration tests to verify the same.
Also, tried UpdateAsync with tablerow data, but postman APIs dont seem to support, and there is no mention of it in API Changelogs.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
