### PR TITLE
Set default Notion-Version to 2022-06-28

### DIFF
--- a/Src/Notion.Client/Constants.cs
+++ b/Src/Notion.Client/Constants.cs
@@ -6,6 +6,6 @@ namespace Notion.Client
     internal class Constants
     {
         internal static string BASE_URL = "https://api.notion.com/";
-        internal static string DEFAULT_NOTION_VERSION = "2022-02-22";
+        internal static string DEFAULT_NOTION_VERSION = "2022-06-28";
     }
 }


### PR DESCRIPTION
## Description

Set default Notion-Version to 2022-06-28

Fixes # (issue)
#257 

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (feature that would cause existing functionality to not work as expected)