### PR TITLE
Update page properties to only return property id

### DIFF
--- a/Src/Notion.Client/Models/Page/Page.cs
+++ b/Src/Notion.Client/Models/Page/Page.cs
@@ -44,7 +44,7 @@ namespace Notion.Client
         /// Property values of this page.
         /// </summary>
         [JsonProperty("properties")]
-        public IDictionary<string, PropertyValue> Properties { get; set; }
+        public IDictionary<string, PagePropertyOnId> Properties { get; set; }
 
         /// <summary>
         /// The URL of the Notion page.

--- a/Src/Notion.Client/Models/Page/PagePropertyOnId.cs
+++ b/Src/Notion.Client/Models/Page/PagePropertyOnId.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public class PagePropertyOnId
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+    }
+}

--- a/Test/Notion.IntegrationTests/IPageClientTests.cs
+++ b/Test/Notion.IntegrationTests/IPageClientTests.cs
@@ -202,7 +202,12 @@ namespace Notion.IntegrationTests
 
             var page = await _client.Pages.CreateAsync(pagesCreateParameters);
 
-            var setDate = page.Properties[datePropertyName] as DatePropertyValue;
+
+            var setDate = (DatePropertyValue)await _client.Pages.RetrievePagePropertyItem(new RetrievePropertyItemParameters
+            {
+                PageId = page.Id,
+                PropertyId = page.Properties[datePropertyName].Id
+            });
 
             setDate?.Date?.Start.Should().Be(Convert.ToDateTime("2020-12-08T12:00:00Z"));
 
@@ -215,7 +220,12 @@ namespace Notion.IntegrationTests
                 Properties = testProps
             });
 
-            var verifyDate = updatedPage.Properties[datePropertyName] as DatePropertyValue;
+
+            var verifyDate = (DatePropertyValue)await _client.Pages.RetrievePagePropertyItem(new RetrievePropertyItemParameters
+            {
+                PageId = page.Id,
+                PropertyId = updatedPage.Properties[datePropertyName].Id
+            });
 
             verifyDate?.Date.Should().BeNull();
 

--- a/Test/Notion.IntegrationTests/IPageClientTests.cs
+++ b/Test/Notion.IntegrationTests/IPageClientTests.cs
@@ -202,7 +202,6 @@ namespace Notion.IntegrationTests
 
             var page = await _client.Pages.CreateAsync(pagesCreateParameters);
 
-
             var setDate = (DatePropertyValue)await _client.Pages.RetrievePagePropertyItem(new RetrievePropertyItemParameters
             {
                 PageId = page.Id,
@@ -219,7 +218,6 @@ namespace Notion.IntegrationTests
             {
                 Properties = testProps
             });
-
 
             var verifyDate = (DatePropertyValue)await _client.Pages.RetrievePagePropertyItem(new RetrievePropertyItemParameters
             {

--- a/Test/Notion.UnitTests/DatabasesClientTests.cs
+++ b/Test/Notion.UnitTests/DatabasesClientTests.cs
@@ -464,7 +464,14 @@ namespace Notion.UnitTests
                 page.Parent.Should().BeAssignableTo<IPageParent>();
                 page.Object.Should().Be(ObjectType.Page);
 
-                var formulaPropertyValue = (FormulaPropertyValue)await _pagesClient.RetrievePagePropertyItem(new RetrievePropertyItemParameters
+                Server.Given(CreateGetRequestBuilder(ApiEndpoints.PagesApiUrls.RetrievePropertyItem(page.Id, page.Properties["FormulaProp"].Id)))
+                .RespondWith(
+                    Response.Create()
+                    .WithStatusCode(200)
+                    .WithBody("{\"object\":\"property_item\",\"id\":\"JwY^\",\"type\":\"formula\",\"formula\":{\"type\":\"date\",\"date\":{\"start\":\"2021-06-28\",\"end\":null}}}")
+                );
+
+                var formulaPropertyValue = (FormulaPropertyItem)await _pagesClient.RetrievePagePropertyItem(new RetrievePropertyItemParameters
                 {
                     PageId = page.Id,
                     PropertyId = page.Properties["FormulaProp"].Id

--- a/Test/Notion.UnitTests/DatabasesClientTests.cs
+++ b/Test/Notion.UnitTests/DatabasesClientTests.cs
@@ -12,10 +12,11 @@ namespace Notion.UnitTests
     public class DatabasesClientTests : ApiTestBase
     {
         private readonly IDatabasesClient _client;
-
+        private readonly IPagesClient _pagesClient;
         public DatabasesClientTests()
         {
             _client = new DatabasesClient(new RestClient(ClientOptions));
+            _pagesClient = new PagesClient(new RestClient(ClientOptions));
         }
 
         [Fact]
@@ -463,7 +464,13 @@ namespace Notion.UnitTests
                 page.Parent.Should().BeAssignableTo<IPageParent>();
                 page.Object.Should().Be(ObjectType.Page);
 
-                var formulaPropertyValue = (FormulaPropertyValue)page.Properties["FormulaProp"];
+                var formulaPropertyValue = (FormulaPropertyValue)await _pagesClient.RetrievePagePropertyItem(new RetrievePropertyItemParameters
+                {
+                    PageId = page.Id,
+                    PropertyId = page.Properties["FormulaProp"].Id
+                });
+
+                //var formulaPropertyValue = (FormulaPropertyValue)page.Properties["FormulaProp"];
                 formulaPropertyValue.Formula.Date.Start.Should().Be(DateTime.Parse("2021-06-28"));
                 formulaPropertyValue.Formula.Date.End.Should().BeNull();
             }

--- a/Test/Notion.UnitTests/PagesClientTests.cs
+++ b/Test/Notion.UnitTests/PagesClientTests.cs
@@ -109,7 +109,14 @@ namespace Notion.UnitTests
             page.Id.Should().Be(pageId);
             page.Properties.Should().HaveCount(2);
             var updatedProperty = page.Properties.First(x => x.Key == "In stock");
-            ((CheckboxPropertyValue)updatedProperty.Value).Checkbox.Should().BeTrue();
+
+            var checkboxPropertyValue = (CheckboxPropertyValue)await _client.RetrievePagePropertyItem(new RetrievePropertyItemParameters
+            {
+                PageId = page.Id,
+                PropertyId = updatedProperty.Value.Id
+            });
+
+            checkboxPropertyValue.Checkbox.Should().BeTrue();
         }
 
         [Fact]
@@ -160,7 +167,14 @@ namespace Notion.UnitTests
             page.IsArchived.Should().BeFalse();
             page.Properties.Should().HaveCount(2);
             var updatedProperty = page.Properties.First(x => x.Key == "In stock");
-            ((CheckboxPropertyValue)updatedProperty.Value).Checkbox.Should().BeTrue();
+
+            var checkboxPropertyValue = (CheckboxPropertyValue)await _client.RetrievePagePropertyItem(new RetrievePropertyItemParameters
+            {
+                PageId = page.Id,
+                PropertyId = updatedProperty.Value.Id
+            });
+
+            checkboxPropertyValue.Checkbox.Should().BeTrue();
         }
 
         [Fact]
@@ -193,7 +207,14 @@ namespace Notion.UnitTests
             page.IsArchived.Should().BeTrue();
             page.Properties.Should().HaveCount(2);
             var updatedProperty = page.Properties.First(x => x.Key == "In stock");
-            ((CheckboxPropertyValue)updatedProperty.Value).Checkbox.Should().BeTrue();
+
+            var checkboxPropertyValue = (CheckboxPropertyValue)await _client.RetrievePagePropertyItem(new RetrievePropertyItemParameters
+            {
+                PageId = page.Id,
+                PropertyId = updatedProperty.Value.Id
+            });
+
+            checkboxPropertyValue.Checkbox.Should().BeTrue();
         }
 
         [Fact]

--- a/Test/Notion.UnitTests/PagesClientTests.cs
+++ b/Test/Notion.UnitTests/PagesClientTests.cs
@@ -88,6 +88,7 @@ namespace Notion.UnitTests
         public async Task UpdatePropertiesAsync()
         {
             var pageId = "251d2b5f-268c-4de2-afe9-c71ff92ca95c";
+            var propertyId = "{>U;";
             var path = ApiEndpoints.PagesApiUrls.UpdateProperties(pageId);
 
             var jsonData = await File.ReadAllTextAsync("data/pages/UpdatePagePropertiesResponse.json");
@@ -98,6 +99,10 @@ namespace Notion.UnitTests
                     .WithStatusCode(200)
                     .WithBody(jsonData)
             );
+
+            Server.Given(CreateGetRequestBuilder(ApiEndpoints.PagesApiUrls.RetrievePropertyItem(pageId, propertyId)))
+                .RespondWith(
+                Response.Create().WithStatusCode(200).WithBody("{\"object\":\"property_item\",\"id\":\"{>U;\",\"type\":\"checkbox\",\"checkbox\":true}"));
 
             var updatedProperties = new Dictionary<string, PropertyValue>()
             {
@@ -110,7 +115,7 @@ namespace Notion.UnitTests
             page.Properties.Should().HaveCount(2);
             var updatedProperty = page.Properties.First(x => x.Key == "In stock");
 
-            var checkboxPropertyValue = (CheckboxPropertyValue)await _client.RetrievePagePropertyItem(new RetrievePropertyItemParameters
+            var checkboxPropertyValue = (CheckboxPropertyItem)await _client.RetrievePagePropertyItem(new RetrievePropertyItemParameters
             {
                 PageId = page.Id,
                 PropertyId = updatedProperty.Value.Id
@@ -142,6 +147,7 @@ namespace Notion.UnitTests
         public async Task UpdatePageAsync()
         {
             var pageId = "251d2b5f-268c-4de2-afe9-c71ff92ca95c";
+            var propertyId = "{>U;";
             var path = ApiEndpoints.PagesApiUrls.UpdateProperties(pageId);
 
             var jsonData = await File.ReadAllTextAsync("data/pages/UpdatePagePropertiesResponse.json");
@@ -152,6 +158,10 @@ namespace Notion.UnitTests
                     .WithStatusCode(200)
                     .WithBody(jsonData)
             );
+
+            Server.Given(CreateGetRequestBuilder(ApiEndpoints.PagesApiUrls.RetrievePropertyItem(pageId, propertyId)))
+                .RespondWith(
+                Response.Create().WithStatusCode(200).WithBody("{\"object\":\"property_item\",\"id\":\"{>U;\",\"type\":\"checkbox\",\"checkbox\":true}"));
 
             var pagesUpdateParameters = new PagesUpdateParameters
             {
@@ -168,7 +178,7 @@ namespace Notion.UnitTests
             page.Properties.Should().HaveCount(2);
             var updatedProperty = page.Properties.First(x => x.Key == "In stock");
 
-            var checkboxPropertyValue = (CheckboxPropertyValue)await _client.RetrievePagePropertyItem(new RetrievePropertyItemParameters
+            var checkboxPropertyValue = (CheckboxPropertyItem)await _client.RetrievePagePropertyItem(new RetrievePropertyItemParameters
             {
                 PageId = page.Id,
                 PropertyId = updatedProperty.Value.Id
@@ -181,6 +191,8 @@ namespace Notion.UnitTests
         public async Task ArchivePageAsync()
         {
             var pageId = "251d2b5f-268c-4de2-afe9-c71ff92ca95c";
+            var propertyId = "{>U;";
+
             var path = ApiEndpoints.PagesApiUrls.UpdateProperties(pageId);
 
             var jsonData = await File.ReadAllTextAsync("data/pages/ArchivePageResponse.json");
@@ -191,6 +203,10 @@ namespace Notion.UnitTests
                     .WithStatusCode(200)
                     .WithBody(jsonData)
             );
+
+            Server.Given(CreateGetRequestBuilder(ApiEndpoints.PagesApiUrls.RetrievePropertyItem(pageId, propertyId)))
+                .RespondWith(
+                Response.Create().WithStatusCode(200).WithBody("{\"object\":\"property_item\",\"id\":\"{>U;\",\"type\":\"checkbox\",\"checkbox\":true}"));
 
             var pagesUpdateParameters = new PagesUpdateParameters
             {
@@ -208,7 +224,7 @@ namespace Notion.UnitTests
             page.Properties.Should().HaveCount(2);
             var updatedProperty = page.Properties.First(x => x.Key == "In stock");
 
-            var checkboxPropertyValue = (CheckboxPropertyValue)await _client.RetrievePagePropertyItem(new RetrievePropertyItemParameters
+            var checkboxPropertyValue = (CheckboxPropertyItem)await _client.RetrievePagePropertyItem(new RetrievePropertyItemParameters
             {
                 PageId = page.Id,
                 PropertyId = updatedProperty.Value.Id

--- a/Test/Notion.UnitTests/data/databases/Fix123QueryAsyncDateFormulaValueReturnsNullResponse.json
+++ b/Test/Notion.UnitTests/data/databases/Fix123QueryAsyncDateFormulaValueReturnsNullResponse.json
@@ -36,7 +36,7 @@
           }
         },
         "FormulaProp": {
-          "id": "JwY^",
+          "id": "JwY",
           "type": "formula",
           "formula": {
             "type": "date",


### PR DESCRIPTION
## Description

From notion version 2022-06-28 - page object only return the properties ids to avoid slowing down the API.

Fixes # (issue)
#258 

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
