### PR TITLE
Fix issue when parsing description property

### DIFF
--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/DatabasesCreateParameters.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/DatabasesCreateParameters.cs
@@ -22,6 +22,6 @@ namespace Notion.Client
 
         public bool? IsInline { get; set; }
 
-        public string Description { get; set; }
+        public List<RichTextBaseInput> Description { get; set; }
     }
 }

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/IDatabasesCreateBodyParameters.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/IDatabasesCreateBodyParameters.cs
@@ -18,6 +18,6 @@ namespace Notion.Client
         bool? IsInline { get; set; }
 
         [JsonProperty("description")]
-        string Description { get; set; }
+        List<RichTextBaseInput> Description { get; set; }
     }
 }

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/DatabasesUpdateParameters.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/DatabasesUpdateParameters.cs
@@ -17,6 +17,6 @@ namespace Notion.Client
 
         public bool? IsInline { get; set; }
 
-        public string Description { get; set; }
+        public List<RichTextBaseInput> Description { get; set; }
     }
 }

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/IDatabasesUpdateBodyParameters.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/IDatabasesUpdateBodyParameters.cs
@@ -24,6 +24,6 @@ namespace Notion.Client
         bool? IsInline { get; set; }
 
         [JsonProperty("description")]
-        string Description { get; set; }
+        List<RichTextBaseInput> Description { get; set; }
     }
 }

--- a/Src/Notion.Client/Models/Database/Database.cs
+++ b/Src/Notion.Client/Models/Database/Database.cs
@@ -51,6 +51,6 @@ namespace Notion.Client
         public bool IsInline { get; set; }
 
         [JsonProperty("description")]
-        public string Description { get; set; }
+        public IEnumerable<RichTextBase> Description { get; set; }
     }
 }


### PR DESCRIPTION
## Description

Fix error parsing description property. Description property is not string but array of rich text

Fixes # (issue)
#299 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
