### PR TITLE
Make color enum property nullable

### DIFF
--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/SelectOptionSchema.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesCreateParameters/PropertySchema/SelectOptionSchema.cs
@@ -10,6 +10,6 @@ namespace Notion.Client
 
         [JsonProperty("color")]
         [JsonConverter(typeof(StringEnumConverter))]
-        public Color Color { get; set; }
+        public Color? Color { get; set; }
     }
 }

--- a/Src/Notion.Client/Models/Blocks/BulletedListItemBlock.cs
+++ b/Src/Notion.Client/Models/Blocks/BulletedListItemBlock.cs
@@ -18,7 +18,7 @@ namespace Notion.Client
 
             [JsonProperty("color")]
             [JsonConverter(typeof(StringEnumConverter))]
-            public Color Color { get; set; }
+            public Color? Color { get; set; }
 
             [JsonProperty("children")]
             public IEnumerable<INonColumnBlock> Children { get; set; }

--- a/Src/Notion.Client/Models/Blocks/CalloutBlock.cs
+++ b/Src/Notion.Client/Models/Blocks/CalloutBlock.cs
@@ -21,7 +21,7 @@ namespace Notion.Client
 
             [JsonProperty("color")]
             [JsonConverter(typeof(StringEnumConverter))]
-            public Color Color { get; set; }
+            public Color? Color { get; set; }
 
             [JsonProperty("children")]
             public IEnumerable<INonColumnBlock> Children { get; set; }

--- a/Src/Notion.Client/Models/Blocks/HeadingOneBlock.cs
+++ b/Src/Notion.Client/Models/Blocks/HeadingOneBlock.cs
@@ -20,7 +20,7 @@ namespace Notion.Client
 
             [JsonProperty("color")]
             [JsonConverter(typeof(StringEnumConverter))]
-            public Color Color { get; set; }
+            public Color? Color { get; set; }
         }
     }
 }

--- a/Src/Notion.Client/Models/Blocks/HeadingThreeeBlock.cs
+++ b/Src/Notion.Client/Models/Blocks/HeadingThreeeBlock.cs
@@ -20,7 +20,7 @@ namespace Notion.Client
 
             [JsonProperty("color")]
             [JsonConverter(typeof(StringEnumConverter))]
-            public Color Color { get; set; }
+            public Color? Color { get; set; }
         }
     }
 }

--- a/Src/Notion.Client/Models/Blocks/HeadingTwoBlock.cs
+++ b/Src/Notion.Client/Models/Blocks/HeadingTwoBlock.cs
@@ -20,7 +20,7 @@ namespace Notion.Client
 
             [JsonProperty("color")]
             [JsonConverter(typeof(StringEnumConverter))]
-            public Color Color { get; set; }
+            public Color? Color { get; set; }
         }
     }
 }

--- a/Src/Notion.Client/Models/Blocks/NumberedListItemBlock.cs
+++ b/Src/Notion.Client/Models/Blocks/NumberedListItemBlock.cs
@@ -18,7 +18,7 @@ namespace Notion.Client
 
             [JsonProperty("color")]
             [JsonConverter(typeof(StringEnumConverter))]
-            public Color Color { get; set; }
+            public Color? Color { get; set; }
 
             [JsonProperty("children")]
             public IEnumerable<INonColumnBlock> Children { get; set; }

--- a/Src/Notion.Client/Models/Blocks/ParagraphBlock.cs
+++ b/Src/Notion.Client/Models/Blocks/ParagraphBlock.cs
@@ -18,7 +18,7 @@ namespace Notion.Client
 
             [JsonProperty("color")]
             [JsonConverter(typeof(StringEnumConverter))]
-            public Color Color { get; set; }
+            public Color? Color { get; set; }
 
             [JsonProperty("children")]
             public IEnumerable<INonColumnBlock> Children { get; set; }

--- a/Src/Notion.Client/Models/Blocks/QuoteBlock.cs
+++ b/Src/Notion.Client/Models/Blocks/QuoteBlock.cs
@@ -18,7 +18,7 @@ namespace Notion.Client
 
             [JsonProperty("color")]
             [JsonConverter(typeof(StringEnumConverter))]
-            public Color Color { get; set; }
+            public Color? Color { get; set; }
 
             [JsonProperty("children")]
             public IEnumerable<INonColumnBlock> Children { get; set; }

--- a/Src/Notion.Client/Models/Blocks/TableOfContentsBlock.cs
+++ b/Src/Notion.Client/Models/Blocks/TableOfContentsBlock.cs
@@ -14,7 +14,7 @@ namespace Notion.Client
         {
             [JsonProperty("color")]
             [JsonConverter(typeof(StringEnumConverter))]
-            public Color Color { get; set; }
+            public Color? Color { get; set; }
         }
     }
 }

--- a/Src/Notion.Client/Models/Blocks/ToDoBlock.cs
+++ b/Src/Notion.Client/Models/Blocks/ToDoBlock.cs
@@ -21,7 +21,7 @@ namespace Notion.Client
 
             [JsonProperty("color")]
             [JsonConverter(typeof(StringEnumConverter))]
-            public Color Color { get; set; }
+            public Color? Color { get; set; }
 
             [JsonProperty("children")]
             public IEnumerable<INonColumnBlock> Children { get; set; }

--- a/Src/Notion.Client/Models/Blocks/ToggleBlock.cs
+++ b/Src/Notion.Client/Models/Blocks/ToggleBlock.cs
@@ -18,7 +18,7 @@ namespace Notion.Client
 
             [JsonProperty("color")]
             [JsonConverter(typeof(StringEnumConverter))]
-            public Color Color { get; set; }
+            public Color? Color { get; set; }
 
             [JsonProperty("children")]
             public IEnumerable<INonColumnBlock> Children { get; set; }

--- a/Src/Notion.Client/Models/Database/Properties/SelectProperty.cs
+++ b/Src/Notion.Client/Models/Database/Properties/SelectProperty.cs
@@ -35,7 +35,7 @@ namespace Notion.Client
         /// </summary>
         [JsonProperty("color")]
         [JsonConverter(typeof(StringEnumConverter))]
-        public Color Color { get; set; }
+        public Color? Color { get; set; }
     }
 
     public class MultiSelectProperty : Property

--- a/Src/Notion.Client/Models/Database/RichText/RichTextBase.cs
+++ b/Src/Notion.Client/Models/Database/RichText/RichTextBase.cs
@@ -43,6 +43,6 @@ namespace Notion.Client
 
         [JsonProperty("color")]
         [JsonConverter(typeof(StringEnumConverter))]
-        public Color Color { get; set; }
+        public Color? Color { get; set; }
     }
 }

--- a/Src/Notion.Client/Models/PropertyValue/StatusPropertyValue.cs
+++ b/Src/Notion.Client/Models/PropertyValue/StatusPropertyValue.cs
@@ -33,7 +33,7 @@ namespace Notion.Client
             /// </summary>
             [JsonProperty("color")]
             [JsonConverter(typeof(StringEnumConverter))]
-            public Color Color { get; set; }
+            public Color? Color { get; set; }
         }
 
         public enum Color

--- a/Test/Notion.IntegrationTests/IPageClientTests.cs
+++ b/Test/Notion.IntegrationTests/IPageClientTests.cs
@@ -142,7 +142,7 @@ namespace Notion.IntegrationTests
 
             var listProperty = (ListPropertyItem)property;
 
-            listProperty.Type.Should().BeNull();
+            listProperty.Type.Should().NotBeNull();
             listProperty.Results.Should().SatisfyRespectively(p =>
             {
                 p.Should().BeOfType<TitlePropertyItem>();
@@ -202,7 +202,11 @@ namespace Notion.IntegrationTests
 
             var page = await _client.Pages.CreateAsync(pagesCreateParameters);
 
-            var setDate = page.Properties[datePropertyName] as DatePropertyValue;
+            var setDate = (DatePropertyItem)await _client.Pages.RetrievePagePropertyItem(new RetrievePropertyItemParameters
+            {
+                PageId = page.Id,
+                PropertyId = page.Properties[datePropertyName].Id
+            });
 
             setDate?.Date?.Start.Should().Be(Convert.ToDateTime("2020-12-08T12:00:00Z"));
 
@@ -215,7 +219,11 @@ namespace Notion.IntegrationTests
                 Properties = testProps
             });
 
-            var verifyDate = updatedPage.Properties[datePropertyName] as DatePropertyValue;
+            var verifyDate = (DatePropertyItem)await _client.Pages.RetrievePagePropertyItem(new RetrievePropertyItemParameters
+            {
+                PageId = page.Id,
+                PropertyId = updatedPage.Properties[datePropertyName].Id
+            });
 
             verifyDate?.Date.Should().BeNull();
 


### PR DESCRIPTION
## Description

Before we converted Color property from string to Enum in release 3.1.0 they can be null and we can set it to null but however when we switched to Enum we lost that ability. This pull request make sure we have ability to set it to null

Fixes # (issue)
#302 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
