### PR TITLE
Fix NumberPropertyItem parsing issue

### DIFF
--- a/Src/Notion.Client/Models/PropertyItems/NumberPropertyItem.cs
+++ b/Src/Notion.Client/Models/PropertyItems/NumberPropertyItem.cs
@@ -7,6 +7,6 @@ namespace Notion.Client
         public override string Type => "number";
 
         [JsonProperty("number")]
-        public double Number { get; set; }
+        public double? Number { get; set; }
     }
 }

--- a/Src/Notion.Client/Models/PropertyItems/NumberPropertyItem.cs
+++ b/Src/Notion.Client/Models/PropertyItems/NumberPropertyItem.cs
@@ -7,6 +7,6 @@ namespace Notion.Client
         public override string Type => "number";
 
         [JsonProperty("number")]
-        public Number Number { get; set; }
+        public double Number { get; set; }
     }
 }


### PR DESCRIPTION
## Description

NumberPropertyItem returns number property with a number value.

Fixes # (issue)
#309 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
