### PR TITLE
Add support for link_preview block type

### DIFF
--- a/Src/Notion.Client/Models/Blocks/BlockType.cs
+++ b/Src/Notion.Client/Models/Blocks/BlockType.cs
@@ -97,6 +97,9 @@ namespace Notion.Client
         [EnumMember(Value = "table_row")]
         TableRow,
 
+        [EnumMember(Value = "link_preview")]
+        LinkPreview,
+
         [EnumMember(Value = "unsupported")]
         Unsupported
     }

--- a/Src/Notion.Client/Models/Blocks/IBlock.cs
+++ b/Src/Notion.Client/Models/Blocks/IBlock.cs
@@ -23,6 +23,7 @@ namespace Notion.Client
     [JsonSubtypes.KnownSubType(typeof(HeadingTwoBlock), BlockType.Heading_2)]
     [JsonSubtypes.KnownSubType(typeof(HeadingThreeeBlock), BlockType.Heading_3)]
     [JsonSubtypes.KnownSubType(typeof(ImageBlock), BlockType.Image)]
+    [JsonSubtypes.KnownSubType(typeof(LinkPreviewBlock), BlockType.LinkPreview)]
     [JsonSubtypes.KnownSubType(typeof(LinkToPageBlock), BlockType.LinkToPage)]
     [JsonSubtypes.KnownSubType(typeof(NumberedListItemBlock), BlockType.NumberedListItem)]
     [JsonSubtypes.KnownSubType(typeof(ParagraphBlock), BlockType.Paragraph)]

--- a/Src/Notion.Client/Models/Blocks/LinkPreviewBlock.cs
+++ b/Src/Notion.Client/Models/Blocks/LinkPreviewBlock.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public class LinkPreviewBlock : Block, IColumnChildrenBlock, INonColumnBlock
+    {
+        public override BlockType Type => BlockType.LinkPreview;
+
+        [JsonProperty("link_preview")] public Data LinkPreview { get; set; }
+
+        public class Data
+        {
+            [JsonProperty("url")] public string Url { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
## Description

Add support for `link_preview` block type

Fixes # (issue)
#323 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
