### PR TITLE
Fix table block children property type

### DIFF
--- a/Src/Notion.Client/Models/Blocks/TableBlock.cs
+++ b/Src/Notion.Client/Models/Blocks/TableBlock.cs
@@ -1,15 +1,16 @@
-﻿using Newtonsoft.Json;
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace Notion.Client
 {
     public class TableBlock : Block, IColumnChildrenBlock, INonColumnBlock
     {
         [JsonProperty("table")]
-        public TableInfo Table { get; set; }
+        public Info Table { get; set; }
 
         public override BlockType Type => BlockType.Table;
 
-        public class TableInfo
+        public class Info
         {
             [JsonProperty("table_width")]
             public int TableWidth { get; set; }
@@ -21,7 +22,7 @@ namespace Notion.Client
             public bool HasRowHeader { get; set; }
 
             [JsonProperty("children")]
-            public TableRowBlock Children { get; set; }
+            public IEnumerable<TableRowBlock> Children { get; set; }
         }
     }
 }

--- a/Test/Notion.IntegrationTests/IBlocksClientTests.cs
+++ b/Test/Notion.IntegrationTests/IBlocksClientTests.cs
@@ -104,7 +104,8 @@ public class IBlocksClientTests : IntegrationTestBase
 
     [Theory]
     [MemberData(nameof(BlockData))]
-    public async Task UpdateAsync_UpdatesGivenBlock(IBlock block, IUpdateBlock updateBlock, Action<IBlock> assert)
+    public async Task UpdateAsync_UpdatesGivenBlock(
+        IBlock block, IUpdateBlock updateBlock, Action<IBlock, INotionClient> assert)
     {
         var page = await Client.Pages.CreateAsync(
             PagesCreateParametersBuilder.Create(
@@ -125,7 +126,7 @@ public class IBlocksClientTests : IntegrationTestBase
 
         var updatedBlock = blocks.Results.First();
 
-        assert.Invoke(updatedBlock);
+        assert.Invoke(updatedBlock, Client);
 
         // cleanup
         await Client.Pages.UpdateAsync(page.Id, new PagesUpdateParameters { Archived = true });
@@ -159,7 +160,7 @@ public class IBlocksClientTests : IntegrationTestBase
                         }
                     }
                 },
-                new Action<IBlock>(block =>
+                new Action<IBlock, INotionClient>((block, client) =>
                 {
                     var updatedBlock = (BookmarkBlock)block;
                     Assert.Equal("https://github.com/notion-dotnet/notion-sdk-net", updatedBlock.Bookmark.Url);
@@ -170,7 +171,7 @@ public class IBlocksClientTests : IntegrationTestBase
             {
                 new EquationBlock { Equation = new EquationBlock.Info { Expression = "e=mc^3" } },
                 new EquationUpdateBlock { Equation = new EquationUpdateBlock.Info { Expression = "e=mc^2" } },
-                new Action<IBlock>(block =>
+                new Action<IBlock, INotionClient>((block, client) =>
                 {
                     var updatedBlock = (EquationBlock)block;
                     Assert.Equal("e=mc^2", updatedBlock.Equation.Expression);
@@ -207,10 +208,10 @@ public class IBlocksClientTests : IntegrationTestBase
                         }
                     }
                 },
-                new Action<IBlock>(block =>
+                new Action<IBlock, INotionClient>((block, client) =>
                 {
                     block.Should().NotBeNull();
-
+            
                     block.Should().BeOfType<AudioBlock>().Subject
                         .Audio.Should().BeOfType<ExternalFile>().Subject
                         .External.Url.Should().Be("https://www.soundhelix.com/examples/mp3/SoundHelix-Song-3.mp3");
@@ -219,7 +220,7 @@ public class IBlocksClientTests : IntegrationTestBase
             new object[]
             {
                 new TableOfContentsBlock { TableOfContents = new TableOfContentsBlock.Data() },
-                new TableOfContentsUpdateBlock(), new Action<IBlock>(block =>
+                new TableOfContentsUpdateBlock(), new Action<IBlock, INotionClient>((block, client) =>
                 {
                     Assert.NotNull(block);
                     _ = Assert.IsType<TableOfContentsBlock>(block);
@@ -247,11 +248,11 @@ public class IBlocksClientTests : IntegrationTestBase
                         }
                     }
                 },
-                new Action<IBlock>(block =>
+                new Action<IBlock, INotionClient>((block, client) =>
                 {
                     Assert.NotNull(block);
                     var calloutBlock = Assert.IsType<CalloutBlock>(block);
-
+            
                     Assert.Equal("Test 2", calloutBlock.Callout.RichText.OfType<RichTextText>().First().Text.Content);
                 })
             },
@@ -277,11 +278,11 @@ public class IBlocksClientTests : IntegrationTestBase
                         }
                     }
                 },
-                new Action<IBlock>(block =>
+                new Action<IBlock, INotionClient>((block, client) =>
                 {
                     Assert.NotNull(block);
                     var quoteBlock = Assert.IsType<QuoteBlock>(block);
-
+            
                     Assert.Equal("Test 2", quoteBlock.Quote.RichText.OfType<RichTextText>().First().Text.Content);
                 })
             },
@@ -308,12 +309,12 @@ public class IBlocksClientTests : IntegrationTestBase
                         }
                     }
                 },
-                new Action<IBlock>(block =>
+                new Action<IBlock, INotionClient>((block, client) =>
                 {
                     Assert.NotNull(block);
                     var imageBlock = Assert.IsType<ImageBlock>(block);
                     var imageFile = Assert.IsType<ExternalFile>(imageBlock.Image);
-
+            
                     Assert.Equal("https://www.iaspaper.net/wp-content/uploads/2017/09/TNEA-Online-Application.jpg",
                         imageFile.External.Url);
                 })
@@ -334,11 +335,11 @@ public class IBlocksClientTests : IntegrationTestBase
                         Url = "https://www.iaspaper.net/wp-content/uploads/2017/09/TNEA-Online-Application.jpg"
                     }
                 },
-                new Action<IBlock>(block =>
+                new Action<IBlock, INotionClient>((block, client) =>
                 {
                     Assert.NotNull(block);
                     var embedBlock = Assert.IsType<EmbedBlock>(block);
-
+            
                     Assert.Equal("https://www.iaspaper.net/wp-content/uploads/2017/09/TNEA-Online-Application.jpg",
                         embedBlock.Embed.Url);
                 })
@@ -376,14 +377,14 @@ public class IBlocksClientTests : IntegrationTestBase
                         }
                     }
                 },
-                new Action<IBlock>(block =>
+                new Action<IBlock, INotionClient>((block, client) =>
                 {
                     Assert.NotNull(block);
                     var templateBlock = Assert.IsType<TemplateBlock>(block);
-
+            
                     Assert.Single(templateBlock.Template.RichText);
                     Assert.Null(templateBlock.Template.Children);
-
+            
                     Assert.Equal("Test Template 2",
                         templateBlock.Template.RichText.OfType<RichTextText>().First().Text.Content);
                 })
@@ -402,16 +403,54 @@ public class IBlocksClientTests : IntegrationTestBase
                 {
                     LinkToPage = new ParentPageInput { PageId = "3c357473a28149a488c010d2b245a589" }
                 },
-                new Action<IBlock>(block =>
+                new Action<IBlock, INotionClient>((block, client) =>
                 {
                     Assert.NotNull(block);
                     var linkToPageBlock = Assert.IsType<LinkToPageBlock>(block);
-
+            
                     var pageParent = Assert.IsType<PageParent>(linkToPageBlock.LinkToPage);
-
+            
                     // TODO: Currently the api doesn't allow to update the link_to_page block type
                     // This will change to updated ID once api start to support
                     Assert.Equal(Guid.Parse("533578e3edf14c0a91a9da6b09bac3ee"), Guid.Parse(pageParent.PageId));
+                })
+            },
+            new object[]
+            {
+                new TableBlock
+                {
+                    Table = new TableBlock.Info
+                    {
+                        TableWidth = 1,
+                        Children = new[]
+                        {
+                            new TableRowBlock
+                            {
+                                TableRow = new TableRowBlock.Info
+                                {
+                                    Cells = new[]
+                                    {
+                                        new[] { new RichTextText { Text = new Text { Content = "Data" } } }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                new TableUpdateBlock { Table = new TableUpdateBlock.Info { HasColumnHeader = false } },
+                new Action<IBlock, INotionClient>((block, client) =>
+                {
+                    var tableBlock = block.Should().NotBeNull().And.BeOfType<TableBlock>().Subject;
+                    tableBlock.HasChildren.Should().BeTrue();
+
+                    var children = client.Blocks.RetrieveChildrenAsync(tableBlock.Id).GetAwaiter().GetResult();
+
+                    children.Results.Should().ContainSingle()
+                        .Subject.Should().BeOfType<TableRowBlock>()
+                        .Subject.TableRow.Cells.Should().ContainSingle()
+                        .Subject.Should().ContainSingle()
+                        .Subject.Should().BeOfType<RichTextText>()
+                        .Subject.Text.Content.Should().Be("Data");
                 })
             }
         };


### PR DESCRIPTION
## Description
Fixes `TableBlock` -> `Children` property data type.

Fixes # (issue)
#347 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
