### PR TITLE
fix: could not deserialize unique_id

### DIFF
--- a/Src/Notion.Client/Models/Database/Properties/Property.cs
+++ b/Src/Notion.Client/Models/Database/Properties/Property.cs
@@ -25,6 +25,7 @@ namespace Notion.Client
     [JsonSubtypes.KnownSubTypeAttribute(typeof(StatusProperty), PropertyType.Status)]
     [JsonSubtypes.KnownSubTypeAttribute(typeof(TitleProperty), PropertyType.Title)]
     [JsonSubtypes.KnownSubTypeAttribute(typeof(UrlProperty), PropertyType.Url)]
+    [JsonSubtypes.KnownSubTypeAttribute(typeof(UniqueIdProperty), PropertyType.UniqueId)]
     public class Property
     {
         [JsonProperty("id")]

--- a/Src/Notion.Client/Models/Database/Properties/PropertyType.cs
+++ b/Src/Notion.Client/Models/Database/Properties/PropertyType.cs
@@ -67,6 +67,9 @@ namespace Notion.Client
         LastEditedTime,
 
         [EnumMember(Value = "status")]
-        Status
+        Status,
+
+        [EnumMember(Value = "unique_id")]
+        UniqueId,        
     }
 }

--- a/Src/Notion.Client/Models/Database/Properties/UniqueIdProperty.cs
+++ b/Src/Notion.Client/Models/Database/Properties/UniqueIdProperty.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{   
+    public class UniqueIdProperty : Property
+    {
+        public override PropertyType Type => PropertyType.UniqueId;
+
+        [JsonProperty("unique_id")]
+        public Dictionary<string, object> UniqueId { get; set; }
+    }
+}
+

--- a/Src/Notion.Client/Models/PropertyValue/PropertyValue.cs
+++ b/Src/Notion.Client/Models/PropertyValue/PropertyValue.cs
@@ -29,6 +29,7 @@ namespace Notion.Client
     [JsonSubtypes.KnownSubTypeAttribute(typeof(StatusPropertyValue), PropertyValueType.Status)]
     [JsonSubtypes.KnownSubTypeAttribute(typeof(TitlePropertyValue), PropertyValueType.Title)]
     [JsonSubtypes.KnownSubTypeAttribute(typeof(UrlPropertyValue), PropertyValueType.Url)]
+    [JsonSubtypes.KnownSubTypeAttribute(typeof(UniqueIdPropertyValue), PropertyValueType.UniqueId)]
     [SuppressMessage("ReSharper", "UnusedMember.Global")]
     [SuppressMessage("ReSharper", "UnassignedGetOnlyAutoProperty")]
     public class PropertyValue

--- a/Src/Notion.Client/Models/PropertyValue/PropertyValueType.cs
+++ b/Src/Notion.Client/Models/PropertyValue/PropertyValueType.cs
@@ -70,6 +70,9 @@ namespace Notion.Client
         LastEditedBy,
 
         [EnumMember(Value = "status")]
-        Status
+        Status,
+
+        [EnumMember(Value = "unique_id")]
+        UniqueId,
     }
 }

--- a/Src/Notion.Client/Models/PropertyValue/UniqueIdPropertyValue.cs
+++ b/Src/Notion.Client/Models/PropertyValue/UniqueIdPropertyValue.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    /// <summary>
+    ///     Unique Id property value object.
+    /// </summary>
+    public class UniqueIdPropertyValue : PropertyValue
+    {
+        public override PropertyValueType Type => PropertyValueType.UniqueId;
+
+        /// <summary>
+        ///     Unique Id property of database item
+        /// </summary>
+        [JsonProperty("unique_id")]
+        public UniqueIdValue UniqueId { get; set; }
+    }
+
+    public class UniqueIdValue
+    {
+        [JsonProperty("prefix")]
+        public string Prefix { get; set; }
+
+        [JsonProperty("number")]
+        public double? Number { get; set; }
+    }
+}
+

--- a/Test/Notion.UnitTests/PropertyTests.cs
+++ b/Test/Notion.UnitTests/PropertyTests.cs
@@ -26,6 +26,7 @@ public class PropertyTests
     [InlineData(typeof(SelectProperty), PropertyType.Select)]
     [InlineData(typeof(TitleProperty), PropertyType.Title)]
     [InlineData(typeof(UrlProperty), PropertyType.Url)]
+    [InlineData(typeof(UniqueIdProperty), PropertyType.UniqueId)]
     public void TestPropertyType(Type type, PropertyType expectedPropertyType)
     {
         var typeInstance = (Property)Activator.CreateInstance(type);
@@ -54,6 +55,7 @@ public class PropertyTests
     [InlineData(typeof(SelectProperty), "select")]
     [InlineData(typeof(TitleProperty), "title")]
     [InlineData(typeof(UrlProperty), "url")]
+    [InlineData(typeof(UniqueIdProperty), "unique_id")]
     public void TestPropertyTypeText(Type type, string expectedPropertyType)
     {
         var typeInstance = (Property)Activator.CreateInstance(type);


### PR DESCRIPTION
## Description

Added support for `unique_id` property type to fix deserialize issue.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
