### PR TITLE
A support for `after` parameter to the Append block children API

### DIFF
--- a/Src/Notion.Client/Api/Blocks/RequestParams/BlocksAppendChildrenParameters.cs
+++ b/Src/Notion.Client/Api/Blocks/RequestParams/BlocksAppendChildrenParameters.cs
@@ -5,5 +5,7 @@ namespace Notion.Client
     public class BlocksAppendChildrenParameters : IBlocksAppendChildrenBodyParameters
     {
         public IEnumerable<IBlock> Children { get; set; }
+
+        public string After { get; set; }
     }
 }

--- a/Src/Notion.Client/Api/Blocks/RequestParams/IBlocksAppendChildrenBodyParameters.cs
+++ b/Src/Notion.Client/Api/Blocks/RequestParams/IBlocksAppendChildrenBodyParameters.cs
@@ -8,5 +8,11 @@ namespace Notion.Client
     {
         [JsonProperty("children")]
         IEnumerable<IBlock> Children { get; set; }
+
+        /// <summary>
+        ///     The ID of the existing block that the new block should be appended after.
+        /// </summary>
+        [JsonProperty("after")]
+        public string After { get; set; }
     }
 }


### PR DESCRIPTION
## Description

A support for `after` parameter to the Append block children API

Fixes #371 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update