### PR TITLE
Add support for `filter_properties` in Database query api query params

### DIFF
--- a/Src/Notion.Client/Api/Databases/DatabasesClient.cs
+++ b/Src/Notion.Client/Api/Databases/DatabasesClient.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using static Notion.Client.ApiEndpoints;
 
@@ -23,8 +25,17 @@ namespace Notion.Client
             DatabasesQueryParameters databasesQueryParameters, CancellationToken cancellationToken = default)
         {
             var body = (IDatabaseQueryBodyParameters)databasesQueryParameters;
+            var queryParameters = (IDatabaseQueryQueryParameters)databasesQueryParameters;
 
-            return await _client.PostAsync<PaginatedList<Page>>(DatabasesApiUrls.Query(databaseId), body, cancellationToken: cancellationToken);
+            var queryParams = queryParameters.FilterProperties?
+                .Select(x => new KeyValuePair<string, string>("filter_properties", x));
+
+            return await _client.PostAsync<PaginatedList<Page>>(
+                DatabasesApiUrls.Query(databaseId),
+                body,
+                queryParams,
+                cancellationToken: cancellationToken
+            );
         }
 
         public async Task<Database> CreateAsync(DatabasesCreateParameters databasesCreateParameters, CancellationToken cancellationToken = default)

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesQueryParameters.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesQueryParameters.cs
@@ -2,7 +2,7 @@
 
 namespace Notion.Client
 {
-    public class DatabasesQueryParameters : IDatabaseQueryBodyParameters
+    public class DatabasesQueryParameters : IDatabaseQueryBodyParameters, IDatabaseQueryQueryParameters
     {
         public Filter Filter { get; set; }
 
@@ -11,5 +11,7 @@ namespace Notion.Client
         public string StartCursor { get; set; }
 
         public int? PageSize { get; set; }
+
+        public List<string> FilterProperties { get; set; }
     }
 }

--- a/Src/Notion.Client/Api/Databases/RequestParams/IDatabaseQueryQueryParameters.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/IDatabaseQueryQueryParameters.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public interface IDatabaseQueryQueryParameters
+    {
+        [JsonProperty("filter_properties")]
+        List<string> FilterProperties { get; set; }
+    }
+}

--- a/Src/Notion.Client/RestClient/IRestClient.cs
+++ b/Src/Notion.Client/RestClient/IRestClient.cs
@@ -17,7 +17,7 @@ namespace Notion.Client
         Task<T> PostAsync<T>(
             string uri,
             object body,
-            IDictionary<string, string> queryParams = null,
+            IEnumerable<KeyValuePair<string, string>> queryParams = null,
             IDictionary<string, string> headers = null,
             JsonSerializerSettings serializerSettings = null,
             CancellationToken cancellationToken = default);

--- a/Src/Notion.Client/RestClient/RestClient.cs
+++ b/Src/Notion.Client/RestClient/RestClient.cs
@@ -45,7 +45,7 @@ namespace Notion.Client
         public async Task<T> PostAsync<T>(
             string uri,
             object body,
-            IDictionary<string, string> queryParams = null,
+            IEnumerable<KeyValuePair<string, string>> queryParams = null,
             IDictionary<string, string> headers = null,
             JsonSerializerSettings serializerSettings = null,
             CancellationToken cancellationToken = default)
@@ -125,7 +125,7 @@ namespace Notion.Client
         private async Task<HttpResponseMessage> SendAsync(
             string requestUri,
             HttpMethod httpMethod,
-            IDictionary<string, string> queryParams = null,
+            IEnumerable<KeyValuePair<string, string>> queryParams = null,
             IDictionary<string, string> headers = null,
             Action<HttpRequestMessage> attachContent = null,
             CancellationToken cancellationToken = default)
@@ -176,7 +176,7 @@ namespace Notion.Client
             _httpClient.BaseAddress = new Uri(_options.BaseUrl);
         }
 
-        private static string AddQueryString(string uri, IDictionary<string, string> queryParams)
+        private static string AddQueryString(string uri, IEnumerable<KeyValuePair<string, string>> queryParams)
         {
             return queryParams == null ? uri : QueryHelpers.AddQueryString(uri, queryParams);
         }

--- a/Src/Notion.Client/http/QueryHelpers.cs
+++ b/Src/Notion.Client/http/QueryHelpers.cs
@@ -45,7 +45,7 @@ namespace Notion.Client.http
             return AddQueryString(uri, (IEnumerable<KeyValuePair<string, string>>)queryParams);
         }
 
-        private static string AddQueryString(
+        public static string AddQueryString(
             string uri,
             IEnumerable<KeyValuePair<string, string>> queryParams)
         {


### PR DESCRIPTION
## Description

Add support for `filter_properties` in Database query api query params

Fixes #370 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
