### PR TITLE
Add wrapper class to avoid sending block id as part of request body

### DIFF
--- a/Src/Notion.Client/Api/Blocks/AppendChildren/BlocksClient.cs
+++ b/Src/Notion.Client/Api/Blocks/AppendChildren/BlocksClient.cs
@@ -17,7 +17,7 @@ namespace Notion.Client
 
             var url = ApiEndpoints.BlocksApiUrls.AppendChildren(request.BlockId);
 
-            var body = (IBlockAppendChildrenBodyParameters)request;
+            var body = new BlockAppendChildrenBodyParameters(request);
 
             return await _client.PatchAsync<AppendChildrenResponse>(url, body, cancellationToken: cancellationToken);
         }

--- a/Src/Notion.Client/Api/Blocks/AppendChildren/Request/IBlockAppendChildrenBodyParameters.cs
+++ b/Src/Notion.Client/Api/Blocks/AppendChildren/Request/IBlockAppendChildrenBodyParameters.cs
@@ -15,4 +15,17 @@ namespace Notion.Client
         [JsonProperty("after")]
         public string After { get; set; }
     }
+
+    internal class BlockAppendChildrenBodyParameters : IBlockAppendChildrenBodyParameters
+    {
+        public IEnumerable<IBlock> Children { get; set; }
+
+        public string After { get; set; }
+
+        public BlockAppendChildrenBodyParameters(BlockAppendChildrenRequest request)
+        {
+            Children = request.Children;
+            After = request.After;
+        }
+    }
 }


### PR DESCRIPTION
## Description
Add wrapper class to avoid sending block id as part of request body

Fixes #398 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)