### PR TITLE
Add support to read/write file name for the file block

### DIFF
--- a/Src/Notion.Client/Models/File/FileObject.cs
+++ b/Src/Notion.Client/Models/File/FileObject.cs
@@ -11,7 +11,7 @@ namespace Notion.Client
     {
         [JsonProperty("caption")]
         public IEnumerable<RichTextBase> Caption { get; set; }
-        
+
         [JsonProperty("name")]
         public string Name { get; set; }
 

--- a/Src/Notion.Client/Models/File/FileObject.cs
+++ b/Src/Notion.Client/Models/File/FileObject.cs
@@ -11,6 +11,9 @@ namespace Notion.Client
     {
         [JsonProperty("caption")]
         public IEnumerable<RichTextBase> Caption { get; set; }
+        
+        [JsonProperty("name")]
+        public string Name { get; set; }
 
         [JsonProperty("type")]
         public virtual string Type { get; set; }


### PR DESCRIPTION
## Description
Adds support to read and write names for the file blocks.

Now, when you retrieve a file block (uploaded or external file), the name of the file is included in the response.
For example:
```
"file": {
  "type": "external",
  "external": {
    "url": "https://example.com/my-file.pdf"
  },
  "caption": [],
  "name": "my-file.pdf"
}
```

Also, it supports setting a custom file name when adding a file block (external file only, since Notion API doesn't support uploading files).

```
var request = new BlockAppendChildrenRequest()
{
    BlockId = "xxx",
    After = "yyy",
    Children = new List<IBlockObjectRequest>()
    {
        new FileBlockRequest()
        {
            File = new ExternalFile()
            {
                External = new ExternalFile.Info()
                {
                    Url = "https://example.com/my-external-file.pdf"
                },
                Name = "my-custom-file-name.pdf"
            }
        }
    }
};

await _notionClient.Blocks.AppendChildrenAsync(request);
```

Documentation reference:
- https://developers.notion.com/reference/block#file