### PR TITLE
Removed 'archived' property and added 'in_trash' property.

### DIFF
--- a/Src/Notion.Client/Api/Blocks/IBlocksClient.cs
+++ b/Src/Notion.Client/Api/Blocks/IBlocksClient.cs
@@ -47,7 +47,7 @@ namespace Notion.Client
         );
 
         /// <summary>
-        ///     Sets a Block object, including page blocks, to archived: true using the ID specified.
+        ///     Moves a Block object, including page blocks, to the trash: true using the ID specified.
         /// </summary>
         /// <param name="blockId">Identifier for a Notion block</param>
         Task DeleteAsync(string blockId, CancellationToken cancellationToken = default);

--- a/Src/Notion.Client/Api/Blocks/RequestParams/BlocksUpdateParameters/UpdateBlocks/BookmarkUpdateBlock.cs
+++ b/Src/Notion.Client/Api/Blocks/RequestParams/BlocksUpdateParameters/UpdateBlocks/BookmarkUpdateBlock.cs
@@ -8,7 +8,7 @@ namespace Notion.Client
         [JsonProperty("bookmark")]
         public Info Bookmark { get; set; }
 
-        public bool Archived { get; set; }
+        public bool InTrash { get; set; }
 
         public class Info
         {

--- a/Src/Notion.Client/Api/Blocks/RequestParams/BlocksUpdateParameters/UpdateBlocks/BreadcrumbUpdateBlock.cs
+++ b/Src/Notion.Client/Api/Blocks/RequestParams/BlocksUpdateParameters/UpdateBlocks/BreadcrumbUpdateBlock.cs
@@ -12,7 +12,7 @@ namespace Notion.Client
         [JsonProperty("breadcrumb")]
         public Info Breadcrumb { get; set; }
 
-        public bool Archived { get; set; }
+        public bool InTrash { get; set; }
 
         public class Info
         {

--- a/Src/Notion.Client/Api/Blocks/RequestParams/BlocksUpdateParameters/UpdateBlocks/DividerUpdateBlock.cs
+++ b/Src/Notion.Client/Api/Blocks/RequestParams/BlocksUpdateParameters/UpdateBlocks/DividerUpdateBlock.cs
@@ -12,7 +12,7 @@ namespace Notion.Client
         [JsonProperty("divider")]
         public Info Divider { get; set; }
 
-        public bool Archived { get; set; }
+        public bool InTrash { get; set; }
 
         public class Info
         {

--- a/Src/Notion.Client/Api/Blocks/RequestParams/BlocksUpdateParameters/UpdateBlocks/IUpdateBlock.cs
+++ b/Src/Notion.Client/Api/Blocks/RequestParams/BlocksUpdateParameters/UpdateBlocks/IUpdateBlock.cs
@@ -4,7 +4,7 @@ namespace Notion.Client
 {
     public interface IUpdateBlock
     {
-        [JsonProperty("archived")]
-        bool Archived { get; set; }
+        [JsonProperty("in_trash")]
+        bool InTrash { get; set; }
     }
 }

--- a/Src/Notion.Client/Api/Blocks/RequestParams/BlocksUpdateParameters/UpdateBlocks/TableOfContentsUpdateBlock.cs
+++ b/Src/Notion.Client/Api/Blocks/RequestParams/BlocksUpdateParameters/UpdateBlocks/TableOfContentsUpdateBlock.cs
@@ -12,7 +12,7 @@ namespace Notion.Client
         [JsonProperty("table_of_contents")]
         public Info TableOfContents { get; set; }
 
-        public bool Archived { get; set; }
+        public bool InTrash { get; set; }
 
         public class Info
         {

--- a/Src/Notion.Client/Api/Blocks/RequestParams/BlocksUpdateParameters/UpdateBlocks/UpdateBlock.cs
+++ b/Src/Notion.Client/Api/Blocks/RequestParams/BlocksUpdateParameters/UpdateBlocks/UpdateBlock.cs
@@ -2,6 +2,6 @@
 {
     public abstract class UpdateBlock : IUpdateBlock
     {
-        public bool Archived { get; set; }
+        public bool InTrash { get; set; }
     }
 }

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/DatabasesUpdateParameters.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/DatabasesUpdateParameters.cs
@@ -12,7 +12,7 @@ namespace Notion.Client
 
         public FileObject Cover { get; set; }
 
-        public bool Archived { get; set; }
+        public bool InTrash { get; set; }
 
         public bool? IsInline { get; set; }
 

--- a/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/IDatabasesUpdateBodyParameters.cs
+++ b/Src/Notion.Client/Api/Databases/RequestParams/DatabasesUpdateParameters/IDatabasesUpdateBodyParameters.cs
@@ -17,8 +17,8 @@ namespace Notion.Client
         [JsonProperty("cover")]
         FileObject Cover { get; set; }
 
-        [JsonProperty("archived")]
-        bool Archived { get; set; }
+        [JsonProperty("in_trash")]
+        bool InTrash { get; set; }
 
         [JsonProperty("is_inline")]
         bool? IsInline { get; set; }

--- a/Src/Notion.Client/Api/Pages/RequestParams/IPagesUpdateBodyParameters.cs
+++ b/Src/Notion.Client/Api/Pages/RequestParams/IPagesUpdateBodyParameters.cs
@@ -5,8 +5,8 @@ namespace Notion.Client
 {
     public interface IPagesUpdateBodyParameters
     {
-        [JsonProperty("archived")]
-        bool Archived { get; set; }
+        [JsonProperty("in_trash")]
+        bool InTrash { get; set; }
 
         [JsonProperty("properties")]
         IDictionary<string, PropertyValue> Properties { get; set; }

--- a/Src/Notion.Client/Api/Pages/RequestParams/PagesUpdateParameters.cs
+++ b/Src/Notion.Client/Api/Pages/RequestParams/PagesUpdateParameters.cs
@@ -11,8 +11,8 @@ namespace Notion.Client
         [JsonProperty("cover")]
         public FileObject Cover { get; set; }
 
-        [JsonProperty("archived")]
-        public bool Archived { get; set; }
+        [JsonProperty("in_trash")]
+        public bool InTrash { get; set; }
 
         [JsonProperty("properties")]
         public IDictionary<string, PropertyValue> Properties { get; set; }

--- a/Src/Notion.Client/Models/Blocks/Block.cs
+++ b/Src/Notion.Client/Models/Blocks/Block.cs
@@ -16,6 +16,8 @@ namespace Notion.Client
 
         public virtual bool HasChildren { get; set; }
 
+        public bool InTrash { get; set; }
+
         public PartialUser CreatedBy { get; set; }
 
         public PartialUser LastEditedBy { get; set; }

--- a/Src/Notion.Client/Models/Blocks/IBlock.cs
+++ b/Src/Notion.Client/Models/Blocks/IBlock.cs
@@ -47,6 +47,9 @@ namespace Notion.Client
         [JsonProperty("has_children")]
         bool HasChildren { get; set; }
 
+        [JsonProperty("in_trash")]
+        bool InTrash { get; set; }
+
         [JsonProperty("parent")]
         IBlockParent Parent { get; set; }
     }

--- a/Src/Notion.Client/Models/Database/Database.cs
+++ b/Src/Notion.Client/Models/Database/Database.cs
@@ -27,11 +27,8 @@ namespace Notion.Client
         [JsonProperty("url")]
         public string Url { get; set; }
 
-        /// <summary>
-        ///     The archived status of the database.
-        /// </summary>
-        [JsonProperty("archived")]
-        public bool Archived { get; set; }
+        [JsonProperty("in_trash")]
+        public bool InTrash { get; set; }
 
         [JsonProperty("is_inline")]
         public bool IsInline { get; set; }

--- a/Src/Notion.Client/Models/Page/Page.cs
+++ b/Src/Notion.Client/Models/Page/Page.cs
@@ -13,10 +13,10 @@ namespace Notion.Client
         public IPageParent Parent { get; set; }
 
         /// <summary>
-        ///     The archived status of the page.
+        ///     Indicates whether the page is currently in the trash.
         /// </summary>
-        [JsonProperty("archived")]
-        public bool IsArchived { get; set; }
+        [JsonProperty("in_trash")]
+        public bool InTrash { get; set; }
 
         /// <summary>
         ///     Property values of this page.

--- a/Test/Notion.IntegrationTests/BlocksClientTests.cs
+++ b/Test/Notion.IntegrationTests/BlocksClientTests.cs
@@ -23,7 +23,7 @@ public class IBlocksClientTests : IntegrationTestBase, IAsyncLifetime
 
     public async Task DisposeAsync()
     {
-        await Client.Pages.UpdateAsync(_page.Id, new PagesUpdateParameters { Archived = true });
+        await Client.Pages.UpdateAsync(_page.Id, new PagesUpdateParameters { InTrash = true });
     }
 
     [Fact]

--- a/Test/Notion.IntegrationTests/CommentsClientTests.cs
+++ b/Test/Notion.IntegrationTests/CommentsClientTests.cs
@@ -21,7 +21,7 @@ public class CommentsClientTests : IntegrationTestBase, IAsyncLifetime
 
     public async Task DisposeAsync()
     {
-        await Client.Pages.UpdateAsync(_page.Id, new PagesUpdateParameters { Archived = true });
+        await Client.Pages.UpdateAsync(_page.Id, new PagesUpdateParameters { InTrash = true });
     }
 
     [Fact]

--- a/Test/Notion.IntegrationTests/DatabasesClientTests.cs
+++ b/Test/Notion.IntegrationTests/DatabasesClientTests.cs
@@ -22,7 +22,7 @@ public class DatabasesClientTests : IntegrationTestBase, IAsyncLifetime
 
     public async Task DisposeAsync()
     {
-        await Client.Pages.UpdateAsync(_page.Id, new PagesUpdateParameters { Archived = true });
+        await Client.Pages.UpdateAsync(_page.Id, new PagesUpdateParameters { InTrash = true });
     }
 
     [Fact]

--- a/Test/Notion.IntegrationTests/PageClientTests.cs
+++ b/Test/Notion.IntegrationTests/PageClientTests.cs
@@ -63,7 +63,7 @@ public class PageClientTests : IntegrationTestBase, IAsyncLifetime
 
     public async Task DisposeAsync()
     {
-        await Client.Pages.UpdateAsync(_page.Id, new PagesUpdateParameters { Archived = true });
+        await Client.Pages.UpdateAsync(_page.Id, new PagesUpdateParameters { InTrash = true });
     }
 
     [Fact]

--- a/Test/Notion.IntegrationTests/PageWithPageParentTests.cs
+++ b/Test/Notion.IntegrationTests/PageWithPageParentTests.cs
@@ -29,7 +29,7 @@ public class PageWithPageParentTests : IntegrationTestBase, IAsyncLifetime
 
     public async Task DisposeAsync()
     {
-        await Client.Pages.UpdateAsync(_page.Id, new PagesUpdateParameters { Archived = true });
+        await Client.Pages.UpdateAsync(_page.Id, new PagesUpdateParameters { InTrash = true });
     }
 
     [Fact]

--- a/Test/Notion.UnitTests/BlocksClientTests.cs
+++ b/Test/Notion.UnitTests/BlocksClientTests.cs
@@ -184,6 +184,7 @@ public class BlocksClientTests : ApiTestBase
 
         block.Id.Should().Be(blockId);
         block.HasChildren.Should().BeFalse();
+        block.InTrash.Should().BeFalse();
         block.Type.Should().Be(BlockType.ToDo);
 
         var todoBlock = (ToDoBlock)block;

--- a/Test/Notion.UnitTests/Notion.UnitTests.csproj
+++ b/Test/Notion.UnitTests/Notion.UnitTests.csproj
@@ -51,7 +51,7 @@
     <None Update="data\databases\UpdateDatabaseResponse.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Update="data\pages\ArchivePageResponse.json">
+    <None Update="data\pages\TrashPageResponse.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="data\pages\CreatePageResponse.json">

--- a/Test/Notion.UnitTests/PagesClientTests.cs
+++ b/Test/Notion.UnitTests/PagesClientTests.cs
@@ -39,7 +39,7 @@ public class PagesClientTests : ApiTestBase
         page.Id.Should().Be(pageId);
         page.Parent.Type.Should().Be(ParentType.DatabaseId);
         ((DatabaseParent)page.Parent).DatabaseId.Should().Be("48f8fee9-cd79-4180-bc2f-ec0398253067");
-        page.IsArchived.Should().BeFalse();
+        page.InTrash.Should().BeFalse();
     }
 
     [Fact]
@@ -72,7 +72,7 @@ public class PagesClientTests : ApiTestBase
         page.Url.Should().NotBeNullOrEmpty();
         page.Properties.Should().HaveCount(1);
         page.Properties.First().Key.Should().Be("Name");
-        page.IsArchived.Should().BeFalse();
+        page.InTrash.Should().BeFalse();
         page.Parent.Should().NotBeNull();
         ((DatabaseParent)page.Parent).DatabaseId.Should().Be("3c357473-a281-49a4-88c0-10d2b245a589");
     }
@@ -172,7 +172,7 @@ public class PagesClientTests : ApiTestBase
         var page = await _client.UpdateAsync(pageId, pagesUpdateParameters);
 
         page.Id.Should().Be(pageId);
-        page.IsArchived.Should().BeFalse();
+        page.InTrash.Should().BeFalse();
         page.Properties.Should().HaveCount(2);
         var updatedProperty = page.Properties.First(x => x.Key == "In stock");
 
@@ -187,14 +187,14 @@ public class PagesClientTests : ApiTestBase
     }
 
     [Fact]
-    public async Task ArchivePageAsync()
+    public async Task TrashPageAsync()
     {
         var pageId = "251d2b5f-268c-4de2-afe9-c71ff92ca95c";
         var propertyId = "{>U;";
 
         var path = ApiEndpoints.PagesApiUrls.UpdateProperties(pageId);
 
-        var jsonData = await File.ReadAllTextAsync("data/pages/ArchivePageResponse.json");
+        var jsonData = await File.ReadAllTextAsync("data/pages/TrashPageResponse.json");
 
         Server.Given(CreatePatchRequestBuilder(path))
             .RespondWith(
@@ -211,7 +211,7 @@ public class PagesClientTests : ApiTestBase
 
         var pagesUpdateParameters = new PagesUpdateParameters
         {
-            Archived = true,
+            InTrash = true,
             Properties = new Dictionary<string, PropertyValue>
             {
                 { "In stock", new CheckboxPropertyValue { Checkbox = true } }
@@ -221,7 +221,7 @@ public class PagesClientTests : ApiTestBase
         var page = await _client.UpdateAsync(pageId, pagesUpdateParameters);
 
         page.Id.Should().Be(pageId);
-        page.IsArchived.Should().BeTrue();
+        page.InTrash.Should().BeTrue();
         page.Properties.Should().HaveCount(2);
         var updatedProperty = page.Properties.First(x => x.Key == "In stock");
 

--- a/Test/Notion.UnitTests/SearchClientTest.cs
+++ b/Test/Notion.UnitTests/SearchClientTest.cs
@@ -59,7 +59,7 @@ public class SearchClientTest : ApiTestBase
                 obj.Object.Should().Be(ObjectType.Page);
 
                 var page = (Page)obj;
-                page.IsArchived.Should().BeFalse();
+                page.InTrash.Should().BeFalse();
                 page.Properties.Should().HaveCount(1);
                 page.Parent.Should().BeAssignableTo<DatabaseParent>();
                 ((DatabaseParent)page.Parent).DatabaseId.Should().Be("e6c6f8ff-c70e-4970-91ba-98f03e0d7fc6");

--- a/Test/Notion.UnitTests/data/blocks/AppendBlockChildrenResponse.json
+++ b/Test/Notion.UnitTests/data/blocks/AppendBlockChildrenResponse.json
@@ -7,6 +7,7 @@
       "created_time": "2021-03-16T16:31:00.000Z",
       "last_edited_time": "2021-03-16T16:32:00.000Z",
       "has_children": false,
+      "in_trash" : false,
       "type": "heading_2",
       "heading_2": {
         "rich_text": [

--- a/Test/Notion.UnitTests/data/blocks/RetrieveBlockChildrenResponse.json
+++ b/Test/Notion.UnitTests/data/blocks/RetrieveBlockChildrenResponse.json
@@ -7,7 +7,7 @@
       "created_time": "2021-05-29T16:22:00.000Z",
       "last_edited_time": "2021-05-29T16:22:00.000Z",
       "has_children": false,
-      "archived": false,
+      "in_trash": false,
       "type": "paragraph",
       "paragraph": {
         "rich_text": []
@@ -19,7 +19,7 @@
       "created_time": "2021-05-30T09:25:00.000Z",
       "last_edited_time": "2021-05-30T09:25:00.000Z",
       "has_children": false,
-      "archived": false,
+      "in_trash": false,
       "type": "heading_2",
       "heading_2": {
         "rich_text": [
@@ -49,7 +49,7 @@
       "created_time": "2021-05-30T09:36:00.000Z",
       "last_edited_time": "2021-05-30T09:36:00.000Z",
       "has_children": false,
-      "archived": false,
+      "in_trash": false,
       "type": "heading_2",
       "heading_2": {
         "rich_text": [
@@ -79,7 +79,7 @@
       "created_time": "2021-08-18T21:12:00.000Z",
       "last_edited_time": "2021-08-18T21:12:00.000Z",
       "has_children": false,
-      "archived": false,
+      "in_trash": false,
       "type": "paragraph",
       "paragraph": {
         "rich_text": []
@@ -91,7 +91,7 @@
       "created_time": "2021-08-18T23:00:00.000Z",
       "last_edited_time": "2021-08-18T23:00:00.000Z",
       "has_children": false,
-      "archived": false,
+      "in_trash": false,
       "type": "child_page",
       "child_page": {
         "title": ""
@@ -103,7 +103,7 @@
       "created_time": "2021-08-18T23:00:00.000Z",
       "last_edited_time": "2021-08-18T23:00:00.000Z",
       "has_children": false,
-      "archived": false,
+      "in_trash": false,
       "type": "child_page",
       "child_page": {
         "title": ""
@@ -115,7 +115,7 @@
       "created_time": "2021-09-09T05:22:00.000Z",
       "last_edited_time": "2021-09-09T05:22:00.000Z",
       "has_children": false,
-      "archived": false,
+      "in_trash": false,
       "type": "paragraph",
       "paragraph": {
         "rich_text": []
@@ -127,7 +127,7 @@
       "created_time": "2022-05-03T13:28:00.000Z",
       "last_edited_time": "2022-05-03T13:29:00.000Z",
       "has_children": false,
-      "archived": false,
+      "in_trash": false,
       "type": "image",
       "image": {
         "caption": [
@@ -174,7 +174,7 @@
             "id": "92e803ec-193c-4bcd-b28e-88365858d562"
         },
         "has_children": true,
-        "archived": false,
+        "in_trash": false,
         "type": "synced_block",
         "synced_block": {
             "synced_from": {

--- a/Test/Notion.UnitTests/data/blocks/RetrieveBlockResponse.json
+++ b/Test/Notion.UnitTests/data/blocks/RetrieveBlockResponse.json
@@ -4,6 +4,7 @@
   "created_time": "2021-03-16T16:31:00.000Z",
   "last_edited_time": "2021-03-16T16:32:00.000Z",
   "has_children": false,
+  "in_trash" : false,
   "type": "to_do",
   "to_do": {
     "rich_text": [

--- a/Test/Notion.UnitTests/data/blocks/UpdateBlockResponse.json
+++ b/Test/Notion.UnitTests/data/blocks/UpdateBlockResponse.json
@@ -4,6 +4,7 @@
   "created_time": "2021-03-16T16:31:00.000Z",
   "last_edited_time": "2021-03-16T16:32:00.000Z",
   "has_children": false,
+  "in_trash" : false,
   "type": "to_do",
   "to_do": {
     "rich_text": [

--- a/Test/Notion.UnitTests/data/databases/DatabaseRetrieveResponse.json
+++ b/Test/Notion.UnitTests/data/databases/DatabaseRetrieveResponse.json
@@ -33,6 +33,7 @@
     }
   },
   "url": "https://www.notion.so/668d797c76fa49349b05ad288df2d136",
+  "in_trash" : false,
   "properties": {
     "Tags": {
       "id": "YG~h",

--- a/Test/Notion.UnitTests/data/databases/DatabasesQueryResponse.json
+++ b/Test/Notion.UnitTests/data/databases/DatabasesQueryResponse.json
@@ -10,7 +10,7 @@
         "type": "database_id",
         "database_id": "897e5a76-ae52-4b48-9fdf-e71f5945d1af"
       },
-      "archived": false,
+      "in_trash": false,
       "url": "https://www.notion.so/2e01e904febd43a0ad028eedb903a82c",
       "properties": {
         "Recipes": {

--- a/Test/Notion.UnitTests/data/databases/Fix123QueryAsyncDateFormulaValueReturnsNullResponse.json
+++ b/Test/Notion.UnitTests/data/databases/Fix123QueryAsyncDateFormulaValueReturnsNullResponse.json
@@ -12,7 +12,7 @@
         "type": "database_id",
         "database_id": "f86f2262-0751-40f2-8f63-e3f7a3c39fcb"
       },
-      "archived": false,
+      "in_trash": false,
       "properties": {
         "Column": {
           "id": "B[\\E",

--- a/Test/Notion.UnitTests/data/pages/CreatePageResponse.json
+++ b/Test/Notion.UnitTests/data/pages/CreatePageResponse.json
@@ -3,7 +3,7 @@
   "id": "251d2b5f-268c-4de2-afe9-c71ff92ca95c",
   "created_time": "2020-03-17T19:10:04.968Z",
   "last_edited_time": "2020-03-17T21:49:37.913Z",
-  "archived": false,
+  "in_trash": false,
   "url": "https://www.notion.so/Test-251d2b5f268c4de2afe9c71ff92ca95c",
   "properties": {
     "Name": {

--- a/Test/Notion.UnitTests/data/pages/PageObjectShouldHaveUrlPropertyResponse.json
+++ b/Test/Notion.UnitTests/data/pages/PageObjectShouldHaveUrlPropertyResponse.json
@@ -7,7 +7,7 @@
     "type": "database_id",
     "database_id": "48f8fee9-cd79-4180-bc2f-ec0398253067"
   },
-  "archived": false,
+  "in_trash": false,
   "url": "https://www.notion.so/Avocado-251d2b5f268c4de2afe9c71ff92ca95c",
   "properties": {
     "Name": {

--- a/Test/Notion.UnitTests/data/pages/TrashPageResponse.json
+++ b/Test/Notion.UnitTests/data/pages/TrashPageResponse.json
@@ -3,7 +3,7 @@
   "id": "251d2b5f-268c-4de2-afe9-c71ff92ca95c",
   "created_time": "2020-03-17T19:10:04.968Z",
   "last_edited_time": "2020-03-17T21:49:37.913Z",
-  "archived": true,
+  "in_trash": true,
   "url": "https://www.notion.so/Test-251d2b5f268c4de2afe9c71ff92ca95c",
   "properties": {
     "In stock": {

--- a/Test/Notion.UnitTests/data/pages/UpdatePagePropertiesResponse.json
+++ b/Test/Notion.UnitTests/data/pages/UpdatePagePropertiesResponse.json
@@ -3,7 +3,7 @@
   "id": "251d2b5f-268c-4de2-afe9-c71ff92ca95c",
   "created_time": "2020-03-17T19:10:04.968Z",
   "last_edited_time": "2020-03-17T21:49:37.913Z",
-  "archived": false,
+  "in_trash": false,
   "url": "https://www.notion.so/Test-251d2b5f268c4de2afe9c71ff92ca95c",
   "properties": {
     "In stock": {

--- a/Test/Notion.UnitTests/data/search/SearchResponse.json
+++ b/Test/Notion.UnitTests/data/search/SearchResponse.json
@@ -4,6 +4,7 @@
   "object": "list",
   "results": [
     {
+      "in_trash": false,
       "created_time": "2021-04-22T22:23:26.080Z",
       "id": "e6c6f8ff-c70e-4970-91ba-98f03e0d7fc6",
       "last_edited_time": "2021-04-23T04:21:00.000Z",
@@ -43,7 +44,7 @@
       ]
     },
     {
-      "archived": false,
+      "in_trash": false,
       "created_time": "2021-04-23T04:21:00.000Z",
       "id": "4f555b50-3a9b-49cb-924c-3746f4ca5522",
       "last_edited_time": "2021-04-23T04:21:00.000Z",


### PR DESCRIPTION
## Description

The Archived properties defined for Block, Page, and Database objects have been deprecated and replaced with new InTrash properties. The API reference has not yet been edited to the new InTrash in some places (block update page), but all API responses seem to have been adapted to InTrash.Migration from Archived to InTrash properties has no functional differences other than the name change, so simply replacing them will cause all existing APIs to work properly.
I have also modified the test code for the areas applicable to the change.

Fixes #410 

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Unit testing was successfully completed and the various APIs (query, update, search) affected by the change were tested in Notion.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Comment

If you need to maintain backward compatibility and support both Archived and InTrash properties, please contact us again!