### PR TITLE
add VerificationProperty

### DIFF
--- a/Src/Notion.Client/Models/Database/Properties/Property.cs
+++ b/Src/Notion.Client/Models/Database/Properties/Property.cs
@@ -27,6 +27,7 @@ namespace Notion.Client
     [JsonSubtypes.KnownSubTypeAttribute(typeof(UrlProperty), PropertyType.Url)]
     [JsonSubtypes.KnownSubTypeAttribute(typeof(UniqueIdProperty), PropertyType.UniqueId)]
     [JsonSubtypes.KnownSubTypeAttribute(typeof(ButtonProperty), PropertyType.Button)]
+    [JsonSubtypes.KnownSubTypeAttribute(typeof(VerificationProperty), PropertyType.Verification)]
     public class Property
     {
         [JsonProperty("id")]

--- a/Src/Notion.Client/Models/Database/Properties/PropertyType.cs
+++ b/Src/Notion.Client/Models/Database/Properties/PropertyType.cs
@@ -74,5 +74,8 @@ namespace Notion.Client
 
         [EnumMember(Value = "button")]
         Button,
+
+        [EnumMember(Value = "verification")]
+        Verification
     }
 }

--- a/Src/Notion.Client/Models/Database/Properties/VerificationProperty.cs
+++ b/Src/Notion.Client/Models/Database/Properties/VerificationProperty.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public class VerificationProperty : Property
+    {
+        public override PropertyType Type => PropertyType.Verification;
+
+        [JsonProperty("verification")]
+        public Dictionary<string, object> Verification { get; set; }
+    }
+}


### PR DESCRIPTION
## Description

Added VerificationProperty to the Database property. This resolves the following issue when querying items such as Notion Wiki pages.

Fixes #475 

Notion Wiki pages are internally treated as databases. When querying Wiki pages, I confirmed that a VerificationProperty is included in the response.

"expiration date":
{
"id": "verification",
"name": "expiration date",
"description": null,
"type": "verification",
"verification": {}
},

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

The unit test completed successfully and I tested with my Notion integration that Wiki page queries and the search API work properly.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
