### PR TITLE
Add support for native page icons

### DIFF
--- a/Src/Notion.Client/Models/Page/PageIcon/IPageIcon.cs
+++ b/Src/Notion.Client/Models/Page/PageIcon/IPageIcon.cs
@@ -4,6 +4,7 @@ using Newtonsoft.Json;
 namespace Notion.Client
 {
     [JsonConverter(typeof(JsonSubtypes), "type")]
+    [JsonSubtypes.KnownSubType(typeof(NativeIconObject), "icon")]
     [JsonSubtypes.KnownSubType(typeof(EmojiPageIcon), PageIconTypes.Emoji)]
     [JsonSubtypes.KnownSubType(typeof(CustomEmojiPageIcon), PageIconTypes.CustomEmoji)]
     [JsonSubtypes.KnownSubType(typeof(FilePageIcon), PageIconTypes.File)]

--- a/Src/Notion.Client/Models/Page/PageIcon/NativeIcon.cs
+++ b/Src/Notion.Client/Models/Page/PageIcon/NativeIcon.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public class NativeIcon
+    {
+        [JsonProperty("color")]
+        public string Color { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+    }
+
+    public class NativeIconObject : IPageIcon
+    {
+        [JsonProperty("icon")]
+        public NativeIcon Icon { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+    }
+}


### PR DESCRIPTION
## Description

The current model class does not support the subtype for native icons (type="icon"), which causes deserialization to fail if they are used.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I have used API functions to access a Notion page that contained a native icon. This failed before the change but succeeds now.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
