### PR TITLE
Remove unnecessary properties

### DIFF
--- a/Src/Notion.Client/Models/DataSource/DataSource.cs
+++ b/Src/Notion.Client/Models/DataSource/DataSource.cs
@@ -79,18 +79,6 @@ namespace Notion.Client
         [JsonProperty("cover")]
         public IPageCover Cover { get; set; }
 
-        /// <summary>
-        /// The URL of the data source.
-        /// </summary>
-        [JsonProperty("url")]
-        public string Url { get; set; }
-
-        /// <summary>
-        /// The public page URL if the data source has been published to the web. Otherwise, null.
-        /// </summary>
-        [JsonProperty("public_url")]
-        public string PublicUrl { get; set; }
-
         [JsonExtensionData]
         public IDictionary<string, object> AdditionalData { get; set; }
     }

--- a/Src/Notion.Client/Models/DataSource/PropertyConfig/RelationProperty/RelationInfo.cs
+++ b/Src/Notion.Client/Models/DataSource/PropertyConfig/RelationProperty/RelationInfo.cs
@@ -10,9 +10,6 @@ namespace Notion.Client
     [JsonSubtypes.KnownSubTypeAttribute(typeof(DualPropertyRelationInfo), "dual_property")]
     public abstract class RelationInfo
     {
-        [JsonProperty("database_id")]
-        public string DatabaseId { get; set; }
-
         [JsonProperty("data_source_id")]
         public string DataSourceId { get; set; }
 

--- a/Src/Notion.Client/Models/Request/Parents/DataSourceParentRequest.cs
+++ b/Src/Notion.Client/Models/Request/Parents/DataSourceParentRequest.cs
@@ -11,9 +11,6 @@ namespace Notion.Client
         [JsonProperty("data_source_id")]
         public string DataSourceId { get; set; }
 
-        [JsonProperty("database_id")]
-        public string DatabaseId { get; set; }
-
         /// <summary>
         /// Additional data for future compatibility
         /// If you encounter properties that are not yet supported, please open an issue on GitHub.


### PR DESCRIPTION
## Description

According to the documentation, it seems that DataSource does not have Url or PublicUrl properties. Upon testing, Url is technically included in the response, but it points to the parent database's URL regardless of the data source, which is misleading — so it's probably better to remove it.
https://developers.notion.com/reference/data-source#object-fields

The DatabaseId in the RelationInfo class and DataSourceParentRequest is no longer needed either.
https://developers.notion.com/reference/property-object#relation

## How Has This Been Tested?

I tested with my Notion integration and confirmed that the query succeeds.
