### PR TITLE
Fix typo in list data source templates URL

### DIFF
--- a/Src/Notion.Client/Api/ApiEndpoints.cs
+++ b/Src/Notion.Client/Api/ApiEndpoints.cs
@@ -155,7 +155,7 @@
             public static string Retrieve(IRetrieveDataSourcePathParameters pathParameters) => $"{BasePath}/{pathParameters.DataSourceId}";
             internal static string CreateDataSource() => BasePath;
             internal static string Update(IUpdateDataSourcePathParameters pathParameters) => $"{BasePath}/{pathParameters.DataSourceId}";
-            internal static string ListDataSourceTemplates(IListDataSourceTemplatesPathParameters pathParameters) => $"/v1/data-sources/{pathParameters.DataSourceId}/templates";
+            internal static string ListDataSourceTemplates(IListDataSourceTemplatesPathParameters pathParameters) => $"/v1/data_sources/{pathParameters.DataSourceId}/templates";
             internal static string Query(IQueryDataSourcePathParameters pathParameters) => $"{BasePath}/{pathParameters.DataSourceId}/query";
         }
     }

--- a/Test/Notion.UnitTests/DataSourcesClientTests.cs
+++ b/Test/Notion.UnitTests/DataSourcesClientTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -150,7 +150,7 @@ public class DataSourcesClientTests
             DataSourceId = dataSourceId
         };
 
-        var expectedEndpoint = $"/v1/data-sources/{dataSourceId}/templates";
+        var expectedEndpoint = $"/v1/data_sources/{dataSourceId}/templates";
         var expectedQueryParams = new Dictionary<string, string>
         {
             { "name", null },
@@ -209,7 +209,7 @@ public class DataSourcesClientTests
             PageSize = pageSize
         };
 
-        var expectedEndpoint = $"/v1/data-sources/{dataSourceId}/templates";
+        var expectedEndpoint = $"/v1/data_sources/{dataSourceId}/templates";
         var expectedQueryParams = new Dictionary<string, string>
         {
             { "name", templateName },
@@ -261,7 +261,7 @@ public class DataSourcesClientTests
             DataSourceId = dataSourceId
         };
 
-        var expectedEndpoint = $"/v1/data-sources/{dataSourceId}/templates";
+        var expectedEndpoint = $"/v1/data_sources/{dataSourceId}/templates";
 
         _restClient
             .Setup(client => client.GetAsync<ListDataSourceTemplatesResponse>(
@@ -302,7 +302,7 @@ public class DataSourcesClientTests
             NextCursor = null
         };
 
-        var expectedEndpoint = $"/v1/data-sources/{dataSourceId}/templates";
+        var expectedEndpoint = $"/v1/data_sources/{dataSourceId}/templates";
         var expectedQueryParams = new Dictionary<string, string>
         {
             { "name", "Test Template" },


### PR DESCRIPTION
## Description

The DataSourcesApiUrls used two different spellings of the URL, "data_sources" and "data-source". Only the first is correct.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Ran the code against a Notion integration. Fetching templates now succeeds.
- [x] Ran the corrected unit tests.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
