### PR TITLE
Add page create position support

### DIFF
--- a/Src/Notion.Client/Api/Pages/RequestParams/PagesCreateParameters/IPagesCreateBodyParameters.cs
+++ b/Src/Notion.Client/Api/Pages/RequestParams/PagesCreateParameters/IPagesCreateBodyParameters.cs
@@ -22,5 +22,8 @@ namespace Notion.Client
 
         [JsonProperty("markdown")]
         string Markdown { get; set; }
+
+        [JsonProperty("position")]
+        IPagePositionRequest Position { get; set; }
     }
 }

--- a/Src/Notion.Client/Api/Pages/RequestParams/PagesCreateParameters/PagePositionRequest.cs
+++ b/Src/Notion.Client/Api/Pages/RequestParams/PagesCreateParameters/PagePositionRequest.cs
@@ -1,0 +1,34 @@
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public interface IPagePositionRequest
+    {
+        [JsonProperty("type")]
+        string Type { get; }
+    }
+
+    public class PageStartPositionRequest : IPagePositionRequest
+    {
+        public string Type => "page_start";
+    }
+
+    public class PageEndPositionRequest : IPagePositionRequest
+    {
+        public string Type => "page_end";
+    }
+
+    public class AfterBlockPagePositionRequest : IPagePositionRequest
+    {
+        public string Type => "after_block";
+
+        [JsonProperty("after_block")]
+        public AfterBlockReference AfterBlock { get; set; }
+    }
+
+    public class AfterBlockReference
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Pages/RequestParams/PagesCreateParameters/PagesCreateParameters.cs
+++ b/Src/Notion.Client/Api/Pages/RequestParams/PagesCreateParameters/PagesCreateParameters.cs
@@ -15,5 +15,7 @@ namespace Notion.Client
         public IPageCoverRequest Cover { get; set; }
 
         public string Markdown { get; set; }
+
+        public IPagePositionRequest Position { get; set; }
     }
 }

--- a/Src/Notion.Client/Api/Pages/RequestParams/PagesCreateParameters/PagesCreateParametersBuilder.cs
+++ b/Src/Notion.Client/Api/Pages/RequestParams/PagesCreateParameters/PagesCreateParametersBuilder.cs
@@ -12,6 +12,7 @@ namespace Notion.Client
         private IPageIconRequest _icon;
         private IParentOfPageRequest _parent;
         private string _markdown;
+        private IPagePositionRequest _position;
 
         private PagesCreateParametersBuilder()
         {
@@ -57,6 +58,13 @@ namespace Notion.Client
             return this;
         }
 
+        public PagesCreateParametersBuilder SetPosition(IPagePositionRequest position)
+        {
+            _position = position;
+
+            return this;
+        }
+
         public PagesCreateParameters Build()
         {
             return new PagesCreateParameters
@@ -66,7 +74,8 @@ namespace Notion.Client
                 Children = _children,
                 Icon = _icon,
                 Cover = _cover,
-                Markdown = _markdown
+                Markdown = _markdown,
+                Position = _position
             };
         }
     }

--- a/Test/Notion.UnitTests/PagesClientTests.cs
+++ b/Test/Notion.UnitTests/PagesClientTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Newtonsoft.Json;
 using Notion.Client;
 using WireMock.ResponseBuilders;
 using Xunit;
@@ -75,6 +76,51 @@ public class PagesClientTests : ApiTestBase
         page.InTrash.Should().BeFalse();
         page.Parent.Should().NotBeNull();
         ((DatabaseParent)page.Parent).DatabaseId.Should().Be("3c357473-a281-49a4-88c0-10d2b245a589");
+    }
+
+    [Fact]
+    public void CreateAsync_Serializes_PageStartPosition()
+    {
+        var pagesCreateParameters = PagesCreateParametersBuilder
+            .Create(new PageParentRequest { PageId = "parent-page-id" })
+            .AddProperty(
+                "title",
+                new TitlePropertyValue
+                {
+                    Title = new List<RichTextBase> { new RichTextText { Text = new Text { Content = "Test" } } }
+                }
+            )
+            .SetPosition(new PageStartPositionRequest())
+            .Build();
+
+        var json = JsonConvert.SerializeObject((IPagesCreateBodyParameters)pagesCreateParameters, RestClient.DefaultSerializerSettings);
+
+        json.Should().Contain(@"""position"":{""type"":""page_start""}");
+    }
+
+    [Fact]
+    public void CreateAsync_Serializes_AfterBlockPosition()
+    {
+        var pagesCreateParameters = PagesCreateParametersBuilder
+            .Create(new PageParentRequest { PageId = "parent-page-id" })
+            .AddProperty(
+                "title",
+                new TitlePropertyValue
+                {
+                    Title = new List<RichTextBase> { new RichTextText { Text = new Text { Content = "Test" } } }
+                }
+            )
+            .SetPosition(
+                new AfterBlockPagePositionRequest
+                {
+                    AfterBlock = new AfterBlockReference { Id = "block-id" }
+                }
+            )
+            .Build();
+
+        var json = JsonConvert.SerializeObject((IPagesCreateBodyParameters)pagesCreateParameters, RestClient.DefaultSerializerSettings);
+
+        json.Should().Contain(@"""position"":{""type"":""after_block"",""after_block"":{""id"":""block-id""}}");
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Adds support for the Notion create page `position` body parameter, allowing callers to place a new child page at the start, end, or after a specific block within a parent page.

Fixes #510

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Added serialization tests for `page_start` and `after_block` page positions
- [x] Ran `dotnet build "Src\Notion.Client\Notion.Client.csproj"`

Full unit tests could not be run locally because the test project targets `net10.0`, while this machine has .NET SDK 9 installed.

**Test Configuration**:
* SDK: .NET SDK 9.0.306

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes