### PR TITLE
Add append block children position support

### DIFF
--- a/Src/Notion.Client/Api/Blocks/AppendChildren/BlocksClient.cs
+++ b/Src/Notion.Client/Api/Blocks/AppendChildren/BlocksClient.cs
@@ -15,6 +15,11 @@ namespace Notion.Client
                 throw new ArgumentNullException(nameof(request.BlockId));
             }
 
+            if (!string.IsNullOrWhiteSpace(request.After) && request.Position != null)
+            {
+                throw new ArgumentException("After and Position cannot both be specified.", nameof(request.Position));
+            }
+
             var url = ApiEndpoints.BlocksApiUrls.AppendChildren(request.BlockId);
 
             var body = new BlockAppendChildrenBodyParameters(request);

--- a/Src/Notion.Client/Api/Blocks/AppendChildren/Request/BlockAppendChildrenRequest.cs
+++ b/Src/Notion.Client/Api/Blocks/AppendChildren/Request/BlockAppendChildrenRequest.cs
@@ -8,6 +8,8 @@ namespace Notion.Client
 
         public string After { get; set; }
 
+        public IBlockChildrenPositionRequest Position { get; set; }
+
         public string BlockId { get; set; }
     }
 }

--- a/Src/Notion.Client/Api/Blocks/AppendChildren/Request/BlockChildrenPositionRequest.cs
+++ b/Src/Notion.Client/Api/Blocks/AppendChildren/Request/BlockChildrenPositionRequest.cs
@@ -1,0 +1,34 @@
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public interface IBlockChildrenPositionRequest
+    {
+        [JsonProperty("type")]
+        string Type { get; }
+    }
+
+    public class StartBlockChildrenPositionRequest : IBlockChildrenPositionRequest
+    {
+        public string Type => "start";
+    }
+
+    public class EndBlockChildrenPositionRequest : IBlockChildrenPositionRequest
+    {
+        public string Type => "end";
+    }
+
+    public class AfterBlockChildrenPositionRequest : IBlockChildrenPositionRequest
+    {
+        public string Type => "after_block";
+
+        [JsonProperty("after_block")]
+        public BlockChildrenPositionReference AfterBlock { get; set; }
+    }
+
+    public class BlockChildrenPositionReference
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Blocks/AppendChildren/Request/IBlockAppendChildrenBodyParameters.cs
+++ b/Src/Notion.Client/Api/Blocks/AppendChildren/Request/IBlockAppendChildrenBodyParameters.cs
@@ -13,6 +13,12 @@ namespace Notion.Client
         /// </summary>
         [JsonProperty("after")]
         public string After { get; set; }
+
+        /// <summary>
+        ///     Controls where the new children should be inserted in the parent block.
+        /// </summary>
+        [JsonProperty("position")]
+        public IBlockChildrenPositionRequest Position { get; set; }
     }
 
     internal class BlockAppendChildrenBodyParameters : IBlockAppendChildrenBodyParameters
@@ -21,10 +27,13 @@ namespace Notion.Client
 
         public string After { get; set; }
 
+        public IBlockChildrenPositionRequest Position { get; set; }
+
         public BlockAppendChildrenBodyParameters(BlockAppendChildrenRequest request)
         {
             Children = request.Children;
             After = request.After;
+            Position = request.Position;
         }
     }
 }

--- a/Test/Notion.UnitTests/BlocksClientTests.cs
+++ b/Test/Notion.UnitTests/BlocksClientTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Newtonsoft.Json;
 using Notion.Client;
 using WireMock.ResponseBuilders;
 using Xunit;
@@ -126,6 +127,73 @@ public class BlocksClientTests : ApiTestBase
                 text.Text.Link.Url.Should().Be("https://en.wikipedia.org/wiki/Lacinato_kale");
             }
         );
+    }
+
+    [Fact]
+    public void AppendBlockChildren_Serializes_StartPosition()
+    {
+        var request = new BlockAppendChildrenRequest
+        {
+            BlockId = "parent-block-id",
+            Children = new List<IBlockObjectRequest>(),
+            Position = new StartBlockChildrenPositionRequest()
+        };
+
+        var json = JsonConvert.SerializeObject(new BlockAppendChildrenBodyParameters(request), RestClient.DefaultSerializerSettings);
+
+        json.Should().Contain(@"""position"":{""type"":""start""}");
+        json.Should().NotContain(@"""after"":");
+    }
+
+    [Fact]
+    public void AppendBlockChildren_Serializes_EndPosition()
+    {
+        var request = new BlockAppendChildrenRequest
+        {
+            BlockId = "parent-block-id",
+            Children = new List<IBlockObjectRequest>(),
+            Position = new EndBlockChildrenPositionRequest()
+        };
+
+        var json = JsonConvert.SerializeObject(new BlockAppendChildrenBodyParameters(request), RestClient.DefaultSerializerSettings);
+
+        json.Should().Contain(@"""position"":{""type"":""end""}");
+        json.Should().NotContain(@"""after"":");
+    }
+
+    [Fact]
+    public void AppendBlockChildren_Serializes_AfterBlockPosition()
+    {
+        var request = new BlockAppendChildrenRequest
+        {
+            BlockId = "parent-block-id",
+            Children = new List<IBlockObjectRequest>(),
+            Position = new AfterBlockChildrenPositionRequest
+            {
+                AfterBlock = new BlockChildrenPositionReference { Id = "child-block-id" }
+            }
+        };
+
+        var json = JsonConvert.SerializeObject(new BlockAppendChildrenBodyParameters(request), RestClient.DefaultSerializerSettings);
+
+        json.Should().Contain(@"""position"":{""type"":""after_block"",""after_block"":{""id"":""child-block-id""}}");
+        json.Should().NotContain(@"""after"":");
+    }
+
+    [Fact]
+    public async Task AppendBlockChildren_Throws_When_After_And_Position_Are_Both_Set()
+    {
+        var request = new BlockAppendChildrenRequest
+        {
+            BlockId = "parent-block-id",
+            Children = new List<IBlockObjectRequest>(),
+            After = "child-block-id",
+            Position = new EndBlockChildrenPositionRequest()
+        };
+
+        var act = async () => await _client.AppendChildrenAsync(request);
+
+        (await act.Should().ThrowAsync<System.ArgumentException>()).And.ParamName.Should().Be("Position");
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Adds support for the new `position` object in the Append block children endpoint while keeping the deprecated `after` parameter for backward compatibility.

The new position models support inserting children at the start, end, or after a specific block. The client now rejects requests that specify both `after` and `position`.

Fixes #517

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Added serialization tests for `start`, `end`, and `after_block` positions
- [x] Added validation coverage for rejecting requests with both `after` and `position`
- [x] Ran `dotnet test "Test\Notion.UnitTests\Notion.UnitTests.csproj"`
- [x] Ran `dotnet build "Notion.sln"`

**Test Configuration**:
* SDK: .NET SDK 10.0.300

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes