### PR TITLE
feat: replace flat 'after' with position object in AppendBlockChildren

### DIFF
--- a/Src/Notion.Client/Api/Blocks/AppendChildren/Request/BlockAppendChildrenRequest.cs
+++ b/Src/Notion.Client/Api/Blocks/AppendChildren/Request/BlockAppendChildrenRequest.cs
@@ -6,7 +6,12 @@ namespace Notion.Client
     {
         public IEnumerable<IBlockObjectRequest> Children { get; set; }
 
-        public string After { get; set; }
+        /// <summary>
+        ///     Controls where the new blocks are placed within the parent.
+        ///     Use <see cref="AfterBlockContentPosition"/>, <see cref="StartContentPosition"/>,
+        ///     or <see cref="EndContentPosition"/>. Defaults to end when omitted.
+        /// </summary>
+        public ContentPosition Position { get; set; }
 
         public string BlockId { get; set; }
     }

--- a/Src/Notion.Client/Api/Blocks/AppendChildren/Request/IBlockAppendChildrenBodyParameters.cs
+++ b/Src/Notion.Client/Api/Blocks/AppendChildren/Request/IBlockAppendChildrenBodyParameters.cs
@@ -9,22 +9,24 @@ namespace Notion.Client
         IEnumerable<IBlockObjectRequest> Children { get; set; }
 
         /// <summary>
-        ///     The ID of the existing block that the new block should be appended after.
+        ///     Controls where the new blocks are placed within the parent.
+        ///     Supports <see cref="AfterBlockContentPosition"/>, <see cref="StartContentPosition"/>,
+        ///     and <see cref="EndContentPosition"/>. Defaults to end when omitted.
         /// </summary>
-        [JsonProperty("after")]
-        public string After { get; set; }
+        [JsonProperty("position")]
+        ContentPosition Position { get; set; }
     }
 
     internal class BlockAppendChildrenBodyParameters : IBlockAppendChildrenBodyParameters
     {
         public IEnumerable<IBlockObjectRequest> Children { get; set; }
 
-        public string After { get; set; }
+        public ContentPosition Position { get; set; }
 
         public BlockAppendChildrenBodyParameters(BlockAppendChildrenRequest request)
         {
             Children = request.Children;
-            After = request.After;
+            Position = request.Position;
         }
     }
 }

--- a/Src/Notion.Client/Models/Blocks/ContentPosition.cs
+++ b/Src/Notion.Client/Models/Blocks/ContentPosition.cs
@@ -1,0 +1,40 @@
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    /// <summary>
+    /// Controls where appended block children are placed within the parent block.
+    /// </summary>
+    public abstract class ContentPosition
+    {
+        [JsonProperty("type")]
+        public abstract string Type { get; }
+    }
+
+    /// <summary>
+    /// Places the new blocks immediately after the specified existing block.
+    /// </summary>
+    public class AfterBlockContentPosition : ContentPosition
+    {
+        public override string Type => "after_block";
+
+        [JsonProperty("after_block")]
+        public AfterBlockReference AfterBlock { get; set; }
+    }
+
+    /// <summary>
+    /// Places the new blocks at the start of the parent block's children.
+    /// </summary>
+    public class StartContentPosition : ContentPosition
+    {
+        public override string Type => "start";
+    }
+
+    /// <summary>
+    /// Places the new blocks at the end of the parent block's children (default behaviour).
+    /// </summary>
+    public class EndContentPosition : ContentPosition
+    {
+        public override string Type => "end";
+    }
+}

--- a/Test/Notion.IntegrationTests/BlocksClientTests.cs
+++ b/Test/Notion.IntegrationTests/BlocksClientTests.cs
@@ -56,6 +56,77 @@ public class IBlocksClientTests : IntegrationTestBase, IAsyncLifetime
     }
 
     [Fact]
+    public async Task AppendChildrenAsync_WithStartPosition_PrependsBlocks()
+    {
+        // Append an initial block
+        var first = await Client.Blocks.AppendChildrenAsync(new BlockAppendChildrenRequest
+        {
+            BlockId = _page.Id,
+            Children = new List<IBlockObjectRequest>
+            {
+                new DividerBlockRequest { Divider = new DividerBlockRequest.Data() }
+            }
+        });
+
+        // Prepend a block using StartContentPosition
+        await Client.Blocks.AppendChildrenAsync(new BlockAppendChildrenRequest
+        {
+            BlockId = _page.Id,
+            Position = new StartContentPosition(),
+            Children = new List<IBlockObjectRequest>
+            {
+                new TableOfContentsBlockRequest { TableOfContents = new TableOfContentsBlockRequest.Data() }
+            }
+        });
+
+        var children = await Client.Blocks.RetrieveChildrenAsync(
+            new BlockRetrieveChildrenRequest { BlockId = _page.Id });
+
+        children.Results.Should().HaveCount(2);
+        children.Results.First().Type.Should().Be(BlockType.TableOfContents);
+        children.Results.Last().Type.Should().Be(BlockType.Divider);
+    }
+
+    [Fact]
+    public async Task AppendChildrenAsync_WithAfterBlockPosition_InsertsAfterSpecifiedBlock()
+    {
+        // Append two initial blocks: A, B
+        var initial = await Client.Blocks.AppendChildrenAsync(new BlockAppendChildrenRequest
+        {
+            BlockId = _page.Id,
+            Children = new List<IBlockObjectRequest>
+            {
+                new DividerBlockRequest { Divider = new DividerBlockRequest.Data() },
+                new TableOfContentsBlockRequest { TableOfContents = new TableOfContentsBlockRequest.Data() }
+            }
+        });
+
+        var blockA = initial.Results.First();
+
+        // Insert a breadcrumb after block A → order should be: A, Breadcrumb, B
+        await Client.Blocks.AppendChildrenAsync(new BlockAppendChildrenRequest
+        {
+            BlockId = _page.Id,
+            Position = new AfterBlockContentPosition
+            {
+                AfterBlock = new AfterBlockReference { Id = blockA.Id }
+            },
+            Children = new List<IBlockObjectRequest>
+            {
+                new BreadcrumbBlockRequest { Breadcrumb = new BreadcrumbBlockRequest.Data() }
+            }
+        });
+
+        var children = await Client.Blocks.RetrieveChildrenAsync(
+            new BlockRetrieveChildrenRequest { BlockId = _page.Id });
+
+        children.Results.Should().HaveCount(3);
+        children.Results[0].Id.Should().Be(blockA.Id);
+        children.Results[1].Type.Should().Be(BlockType.Breadcrumb);
+        children.Results[2].Type.Should().Be(BlockType.TableOfContents);
+    }
+
+    [Fact]
     public async Task UpdateBlockAsync_UpdatesGivenBlock()
     {
         var blocks = await Client.Blocks.AppendChildrenAsync(


### PR DESCRIPTION
Closes #517

## Summary
- Replaces the flat `After` (string) parameter on `BlockAppendChildrenRequest` with a structured `Position` (`ContentPosition`) object, matching the Notion API version `2026-03-11` change
- Adds `ContentPosition` abstract class with three concrete subtypes:
  - `AfterBlockContentPosition` — place after a specific existing block
  - `StartContentPosition` — place at the start of the parent's children
  - `EndContentPosition` — place at the end (API default when omitted)
- `AfterBlockReference` is reused from the existing page-position models

## Breaking change
`BlockAppendChildrenRequest.After` (string) is removed. Use `Position = new AfterBlockContentPosition { AfterBlock = new AfterBlockReference { Id = "..." } }` instead.

## Test plan
- [ ] `AppendChildrenAsync_AppendsBlocksGivenBlocks` — existing test, no position
- [ ] `AppendChildrenAsync_WithStartPosition_PrependsBlocks` — verifies `StartContentPosition`
- [ ] `AppendChildrenAsync_WithAfterBlockPosition_InsertsAfterSpecifiedBlock` — verifies `AfterBlockContentPosition`