### PR TITLE
feat: rename transcription to meeting_notes block type

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(dotnet build:*)"
-    ]
-  }
-}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(dotnet build:*)"
+    ]
+  }
+}

--- a/Src/Notion.Client/Models/Blocks/BlockType.cs
+++ b/Src/Notion.Client/Models/Blocks/BlockType.cs
@@ -50,6 +50,9 @@ namespace Notion.Client
         public const string TableRowValue = "table_row";
         public const string LinkPreviewValue = "link_preview";
         public const string UnsupportedValue = "unsupported";
+        public const string MeetingNotesValue = "meeting_notes";
+
+        [Obsolete("Use MeetingNotesValue instead. 'transcription' was renamed to 'meeting_notes' in Notion API version 2026-03-11.")]
         public const string TranscriptionValue = "transcription";
 
         public static readonly BlockType Paragraph = new BlockType(ParagraphValue);
@@ -85,7 +88,12 @@ namespace Notion.Client
         public static readonly BlockType TableRow = new BlockType(TableRowValue);
         public static readonly BlockType LinkPreview = new BlockType(LinkPreviewValue);
         public static readonly BlockType Unsupported = new BlockType(UnsupportedValue);
+        public static readonly BlockType MeetingNotes = new BlockType(MeetingNotesValue);
+
+#pragma warning disable CS0618
+        [Obsolete("Use MeetingNotes instead. 'transcription' was renamed to 'meeting_notes' in Notion API version 2026-03-11.")]
         public static readonly BlockType Transcription = new BlockType(TranscriptionValue);
+#pragma warning restore CS0618
 
         public static implicit operator BlockType(string value) => new BlockType(value);
 

--- a/Src/Notion.Client/Models/Blocks/IBlock.cs
+++ b/Src/Notion.Client/Models/Blocks/IBlock.cs
@@ -1,3 +1,4 @@
+using System;
 using JsonSubTypes;
 using Newtonsoft.Json;
 
@@ -37,6 +38,10 @@ namespace Notion.Client
     [JsonSubtypes.KnownSubTypeAttribute(typeof(ToggleBlock), BlockType.ToggleValue)]
     [JsonSubtypes.KnownSubTypeAttribute(typeof(VideoBlock), BlockType.VideoValue)]
     [JsonSubtypes.KnownSubTypeAttribute(typeof(UnsupportedBlock), BlockType.UnsupportedValue)]
+    [JsonSubtypes.KnownSubTypeAttribute(typeof(MeetingNotesBlock), BlockType.MeetingNotesValue)]
+#pragma warning disable CS0618
+    [JsonSubtypes.KnownSubTypeAttribute(typeof(TranscriptionBlock), "transcription")]
+#pragma warning restore CS0618
     [JsonSubtypes.FallBackSubTypeAttribute(typeof(UnsupportedBlock))]
     public interface IBlock : IObject, IObjectModificationData
     {

--- a/Src/Notion.Client/Models/Blocks/MeetingNotesBlock.cs
+++ b/Src/Notion.Client/Models/Blocks/MeetingNotesBlock.cs
@@ -1,21 +1,17 @@
-using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Notion.Client
 {
-    [Obsolete("Use MeetingNotesBlock instead. The 'transcription' block type was renamed to 'meeting_notes' in Notion API version 2026-03-11.")]
-    public class TranscriptionBlock : Block
+    public class MeetingNotesBlock : Block
     {
-#pragma warning disable CS0618
-        public override BlockType Type => BlockType.Transcription;
-#pragma warning restore CS0618
+        public override BlockType Type => BlockType.MeetingNotes;
 
-        [JsonProperty("transcription")]
-        public TranscriptionBlockResponse Transcription { get; set; }
+        [JsonProperty("meeting_notes")]
+        public MeetingNotesBlockData MeetingNotes { get; set; }
     }
 
-    public class TranscriptionBlockResponse
+    public class MeetingNotesBlockData
     {
         [JsonProperty("title")]
         public IEnumerable<RichTextBase> Title { get; set; }
@@ -24,16 +20,16 @@ namespace Notion.Client
         public string Status { get; set; }
 
         [JsonProperty("children")]
-        public TranscriptionChildrenResponse Children { get; set; }
+        public MeetingNotesChildrenData Children { get; set; }
 
         [JsonProperty("calendar_event")]
-        public TranscriptionCalendarEventResponse CalendarEvent { get; set; }
+        public MeetingNotesCalendarEventData CalendarEvent { get; set; }
 
         [JsonProperty("recording")]
-        public TranscriptionRecordingResponse Recording { get; set; }
+        public MeetingNotesRecordingData Recording { get; set; }
     }
 
-    public class TranscriptionChildrenResponse
+    public class MeetingNotesChildrenData
     {
         [JsonProperty("summary_block_id")]
         public string SummaryBlockId { get; set; }
@@ -45,7 +41,7 @@ namespace Notion.Client
         public string TranscriptBlockId { get; set; }
     }
 
-    public class TranscriptionCalendarEventResponse
+    public class MeetingNotesCalendarEventData
     {
         [JsonProperty("start_time")]
         public string StartTime { get; set; }
@@ -57,7 +53,7 @@ namespace Notion.Client
         public IEnumerable<string> Attendees { get; set; }
     }
 
-    public class TranscriptionRecordingResponse
+    public class MeetingNotesRecordingData
     {
         [JsonProperty("start_time")]
         public string StartTime { get; set; }


### PR DESCRIPTION
Closes #519

## Summary
As of Notion API version `2026-03-11`, the `transcription` block type is renamed to `meeting_notes`.

- Adds `MeetingNotesBlock` as the new canonical block class with `MeetingNotesBlockData`, `MeetingNotesChildrenData`, `MeetingNotesCalendarEventData`, `MeetingNotesRecordingData`
- Adds `BlockType.MeetingNotesValue = "meeting_notes"` and `BlockType.MeetingNotes`
- Registers `MeetingNotesBlock` in `IBlock` for the `meeting_notes` discriminator
- Marks `TranscriptionBlock`, `BlockType.Transcription`, `BlockType.TranscriptionValue` as `[Obsolete]`
- Keeps backward-compat `KnownSubType` registration for the old `"transcription"` discriminator so existing data continues to deserialize

## Test plan
- [ ] Build with no CS0618 warnings in non-suppressed code
- [ ] Retrieve a meeting notes block from the API and verify it deserializes as `MeetingNotesBlock`