### PR TITLE
feat: add Views API support

### DIFF
--- a/Src/Notion.Client/Api/ApiEndpoints.cs
+++ b/Src/Notion.Client/Api/ApiEndpoints.cs
@@ -143,6 +143,19 @@
             public static string Retrieve(IRetrieveFileUploadPathParameters pathParameters) => $"/v1/file_uploads/{pathParameters.FileUploadId}";
         }
 
+        public static class ViewsApiUrls
+        {
+            private const string BasePath = "/v1/views";
+            public static string List() => BasePath;
+            public static string Create() => BasePath;
+            public static string Retrieve(string viewId) => $"{BasePath}/{viewId}";
+            public static string Update(string viewId) => $"{BasePath}/{viewId}";
+            public static string Delete(string viewId) => $"{BasePath}/{viewId}";
+            public static string CreateQuery(string viewId) => $"{BasePath}/{viewId}/queries";
+            public static string GetQueryResults(string viewId, string queryId) => $"{BasePath}/{viewId}/queries/{queryId}";
+            public static string DeleteQuery(string viewId, string queryId) => $"{BasePath}/{viewId}/queries/{queryId}";
+        }
+
         public static class DataSourcesApiUrls
         {
             private const string BasePath = "/v1/data_sources";

--- a/Src/Notion.Client/Api/Views/Create/Request/CreateViewRequest.cs
+++ b/Src/Notion.Client/Api/Views/Create/Request/CreateViewRequest.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public class CreateViewRequest
+    {
+        [JsonProperty("data_source_id")]
+        public string DataSourceId { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("type")]
+        public ViewType Type { get; set; }
+
+        [JsonProperty("database_id")]
+        public string DatabaseId { get; set; }
+
+        [JsonProperty("filter")]
+        public object Filter { get; set; }
+
+        [JsonProperty("sorts")]
+        public IEnumerable<ViewSort> Sorts { get; set; }
+
+        [JsonProperty("configuration")]
+        public ViewConfiguration Configuration { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Views/Create/ViewsClient.cs
+++ b/Src/Notion.Client/Api/Views/Create/ViewsClient.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Notion.Client
+{
+    public sealed partial class ViewsClient
+    {
+        public async Task<View> CreateAsync(
+            CreateViewRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            var endpoint = ApiEndpoints.ViewsApiUrls.Create();
+
+            return await _restClient.PostAsync<View>(
+                endpoint,
+                request,
+                cancellationToken: cancellationToken
+            );
+        }
+    }
+}

--- a/Src/Notion.Client/Api/Views/Delete/ViewsClient.cs
+++ b/Src/Notion.Client/Api/Views/Delete/ViewsClient.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Notion.Client
+{
+    public sealed partial class ViewsClient
+    {
+        public async Task<View> DeleteAsync(
+            string viewId,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(viewId))
+            {
+                throw new ArgumentException("viewId cannot be null or empty.", nameof(viewId));
+            }
+
+            var endpoint = ApiEndpoints.ViewsApiUrls.Delete(viewId);
+
+            return await _restClient.DeleteAsync<View>(endpoint, cancellationToken: cancellationToken);
+        }
+    }
+}

--- a/Src/Notion.Client/Api/Views/IViewsClient.cs
+++ b/Src/Notion.Client/Api/Views/IViewsClient.cs
@@ -1,0 +1,64 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Notion.Client
+{
+    public interface IViewsClient
+    {
+        /// <summary>
+        /// Lists views for a database or data source.
+        /// </summary>
+        Task<PaginatedList<View>> ListAsync(
+            ListViewsRequest request,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Creates a new view.
+        /// </summary>
+        Task<View> CreateAsync(
+            CreateViewRequest request,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieves a view by its ID.
+        /// </summary>
+        Task<View> RetrieveAsync(
+            string viewId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Updates an existing view.
+        /// </summary>
+        Task<View> UpdateAsync(
+            UpdateViewRequest request,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Deletes a view by its ID.
+        /// </summary>
+        Task<View> DeleteAsync(
+            string viewId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Creates a query against a view.
+        /// </summary>
+        Task<ViewQueryResponse> CreateQueryAsync(
+            CreateViewQueryRequest request,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Gets the results of a previously created view query.
+        /// </summary>
+        Task<PaginatedList<PageReference>> GetQueryResultsAsync(
+            GetViewQueryResultsRequest request,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Deletes a view query.
+        /// </summary>
+        Task<DeletedViewQueryResponse> DeleteQueryAsync(
+            DeleteViewQueryRequest request,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/Src/Notion.Client/Api/Views/List/Request/ListViewsRequest.cs
+++ b/Src/Notion.Client/Api/Views/List/Request/ListViewsRequest.cs
@@ -1,0 +1,10 @@
+namespace Notion.Client
+{
+    public class ListViewsRequest
+    {
+        public string DatabaseId { get; set; }
+        public string DataSourceId { get; set; }
+        public string StartCursor { get; set; }
+        public int? PageSize { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Views/List/ViewsClient.cs
+++ b/Src/Notion.Client/Api/Views/List/ViewsClient.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Notion.Client
+{
+    public sealed partial class ViewsClient
+    {
+        public async Task<PaginatedList<View>> ListAsync(
+            ListViewsRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            var endpoint = ApiEndpoints.ViewsApiUrls.List();
+
+            var queryParams = new Dictionary<string, string>();
+
+            if (!string.IsNullOrEmpty(request.DatabaseId))
+            {
+                queryParams["database_id"] = request.DatabaseId;
+            }
+
+            if (!string.IsNullOrEmpty(request.DataSourceId))
+            {
+                queryParams["data_source_id"] = request.DataSourceId;
+            }
+
+            if (!string.IsNullOrEmpty(request.StartCursor))
+            {
+                queryParams["start_cursor"] = request.StartCursor;
+            }
+
+            if (request.PageSize.HasValue)
+            {
+                queryParams["page_size"] = request.PageSize.Value.ToString();
+            }
+
+            return await _restClient.GetAsync<PaginatedList<View>>(
+                endpoint,
+                queryParams: queryParams,
+                cancellationToken: cancellationToken
+            );
+        }
+    }
+}

--- a/Src/Notion.Client/Api/Views/Queries/Create/Request/CreateViewQueryRequest.cs
+++ b/Src/Notion.Client/Api/Views/Queries/Create/Request/CreateViewQueryRequest.cs
@@ -1,0 +1,16 @@
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public class CreateViewQueryRequest
+    {
+        /// <summary>
+        /// The ID of the view to query. This is a path parameter and is not serialized in the request body.
+        /// </summary>
+        [JsonIgnore]
+        public string ViewId { get; set; }
+
+        [JsonProperty("page_size")]
+        public int? PageSize { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Views/Queries/Create/Response/ViewQueryResponse.cs
+++ b/Src/Notion.Client/Api/Views/Queries/Create/Response/ViewQueryResponse.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public class ViewQueryResponse
+    {
+        [JsonProperty("object")]
+        public string Object { get; set; }
+
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("view_id")]
+        public string ViewId { get; set; }
+
+        [JsonProperty("expires_at")]
+        public DateTime ExpiresAt { get; set; }
+
+        [JsonProperty("total_count")]
+        public int TotalCount { get; set; }
+
+        [JsonProperty("results")]
+        public IEnumerable<PageReference> Results { get; set; }
+
+        [JsonProperty("next_cursor")]
+        public string NextCursor { get; set; }
+
+        [JsonProperty("has_more")]
+        public bool HasMore { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Views/Queries/Create/ViewsClient.cs
+++ b/Src/Notion.Client/Api/Views/Queries/Create/ViewsClient.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Notion.Client
+{
+    public sealed partial class ViewsClient
+    {
+        public async Task<ViewQueryResponse> CreateQueryAsync(
+            CreateViewQueryRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            if (string.IsNullOrWhiteSpace(request.ViewId))
+            {
+                throw new ArgumentException("ViewId cannot be null or empty.", nameof(request.ViewId));
+            }
+
+            var endpoint = ApiEndpoints.ViewsApiUrls.CreateQuery(request.ViewId);
+
+            return await _restClient.PostAsync<ViewQueryResponse>(
+                endpoint,
+                request,
+                cancellationToken: cancellationToken
+            );
+        }
+    }
+}

--- a/Src/Notion.Client/Api/Views/Queries/Delete/Request/DeleteViewQueryRequest.cs
+++ b/Src/Notion.Client/Api/Views/Queries/Delete/Request/DeleteViewQueryRequest.cs
@@ -1,0 +1,8 @@
+namespace Notion.Client
+{
+    public class DeleteViewQueryRequest
+    {
+        public string ViewId { get; set; }
+        public string QueryId { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Views/Queries/Delete/Response/DeletedViewQueryResponse.cs
+++ b/Src/Notion.Client/Api/Views/Queries/Delete/Response/DeletedViewQueryResponse.cs
@@ -1,0 +1,16 @@
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public class DeletedViewQueryResponse
+    {
+        [JsonProperty("object")]
+        public string Object { get; set; }
+
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("deleted")]
+        public bool Deleted { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Views/Queries/Delete/ViewsClient.cs
+++ b/Src/Notion.Client/Api/Views/Queries/Delete/ViewsClient.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Notion.Client
+{
+    public sealed partial class ViewsClient
+    {
+        public async Task<DeletedViewQueryResponse> DeleteQueryAsync(
+            DeleteViewQueryRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            if (string.IsNullOrWhiteSpace(request.ViewId))
+            {
+                throw new ArgumentException("ViewId cannot be null or empty.", nameof(request.ViewId));
+            }
+
+            if (string.IsNullOrWhiteSpace(request.QueryId))
+            {
+                throw new ArgumentException("QueryId cannot be null or empty.", nameof(request.QueryId));
+            }
+
+            var endpoint = ApiEndpoints.ViewsApiUrls.DeleteQuery(request.ViewId, request.QueryId);
+
+            return await _restClient.DeleteAsync<DeletedViewQueryResponse>(endpoint, cancellationToken: cancellationToken);
+        }
+    }
+}

--- a/Src/Notion.Client/Api/Views/Queries/Get/Request/GetViewQueryResultsRequest.cs
+++ b/Src/Notion.Client/Api/Views/Queries/Get/Request/GetViewQueryResultsRequest.cs
@@ -1,0 +1,10 @@
+namespace Notion.Client
+{
+    public class GetViewQueryResultsRequest
+    {
+        public string ViewId { get; set; }
+        public string QueryId { get; set; }
+        public string StartCursor { get; set; }
+        public int? PageSize { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Views/Queries/Get/ViewsClient.cs
+++ b/Src/Notion.Client/Api/Views/Queries/Get/ViewsClient.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Notion.Client
+{
+    public sealed partial class ViewsClient
+    {
+        public async Task<PaginatedList<PageReference>> GetQueryResultsAsync(
+            GetViewQueryResultsRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            if (string.IsNullOrWhiteSpace(request.ViewId))
+            {
+                throw new ArgumentException("ViewId cannot be null or empty.", nameof(request.ViewId));
+            }
+
+            if (string.IsNullOrWhiteSpace(request.QueryId))
+            {
+                throw new ArgumentException("QueryId cannot be null or empty.", nameof(request.QueryId));
+            }
+
+            var endpoint = ApiEndpoints.ViewsApiUrls.GetQueryResults(request.ViewId, request.QueryId);
+
+            var queryParams = new Dictionary<string, string>();
+
+            if (!string.IsNullOrEmpty(request.StartCursor))
+            {
+                queryParams["start_cursor"] = request.StartCursor;
+            }
+
+            if (request.PageSize.HasValue)
+            {
+                queryParams["page_size"] = request.PageSize.Value.ToString();
+            }
+
+            return await _restClient.GetAsync<PaginatedList<PageReference>>(
+                endpoint,
+                queryParams: queryParams,
+                cancellationToken: cancellationToken
+            );
+        }
+    }
+}

--- a/Src/Notion.Client/Api/Views/Retrieve/ViewsClient.cs
+++ b/Src/Notion.Client/Api/Views/Retrieve/ViewsClient.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Notion.Client
+{
+    public sealed partial class ViewsClient
+    {
+        public async Task<View> RetrieveAsync(
+            string viewId,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(viewId))
+            {
+                throw new ArgumentException("viewId cannot be null or empty.", nameof(viewId));
+            }
+
+            var endpoint = ApiEndpoints.ViewsApiUrls.Retrieve(viewId);
+
+            return await _restClient.GetAsync<View>(endpoint, cancellationToken: cancellationToken);
+        }
+    }
+}

--- a/Src/Notion.Client/Api/Views/Update/Request/UpdateViewRequest.cs
+++ b/Src/Notion.Client/Api/Views/Update/Request/UpdateViewRequest.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public class UpdateViewRequest
+    {
+        /// <summary>
+        /// The ID of the view to update. This is a path parameter and is not serialized in the request body.
+        /// </summary>
+        [JsonIgnore]
+        public string ViewId { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("filter")]
+        public object Filter { get; set; }
+
+        [JsonProperty("sorts")]
+        public IEnumerable<UpdateViewSort> Sorts { get; set; }
+
+        [JsonProperty("configuration")]
+        public ViewConfiguration Configuration { get; set; }
+    }
+
+    public class UpdateViewSort
+    {
+        [JsonProperty("property")]
+        public string Property { get; set; }
+
+        [JsonProperty("direction")]
+        public string Direction { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Views/Update/ViewsClient.cs
+++ b/Src/Notion.Client/Api/Views/Update/ViewsClient.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Notion.Client
+{
+    public sealed partial class ViewsClient
+    {
+        public async Task<View> UpdateAsync(
+            UpdateViewRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            if (string.IsNullOrWhiteSpace(request.ViewId))
+            {
+                throw new ArgumentException("ViewId cannot be null or empty.", nameof(request.ViewId));
+            }
+
+            var endpoint = ApiEndpoints.ViewsApiUrls.Update(request.ViewId);
+
+            return await _restClient.PatchAsync<View>(
+                endpoint,
+                request,
+                cancellationToken: cancellationToken
+            );
+        }
+    }
+}

--- a/Src/Notion.Client/Api/Views/ViewsClient.cs
+++ b/Src/Notion.Client/Api/Views/ViewsClient.cs
@@ -1,0 +1,12 @@
+namespace Notion.Client
+{
+    public sealed partial class ViewsClient : IViewsClient
+    {
+        private readonly IRestClient _restClient;
+
+        public ViewsClient(IRestClient restClient)
+        {
+            _restClient = restClient;
+        }
+    }
+}

--- a/Src/Notion.Client/Models/ObjectType.cs
+++ b/Src/Notion.Client/Models/ObjectType.cs
@@ -22,6 +22,7 @@ namespace Notion.Client
         public const string FileUploadValue = "file_upload";
         public const string DataSourceValue = "data_source";
         public const string PageMarkdownValue = "page_markdown";
+        public const string ViewValue = "view";
 
         public static readonly ObjectType Page = new ObjectType(PageValue);
         public static readonly ObjectType Database = new ObjectType(DatabaseValue);
@@ -31,6 +32,7 @@ namespace Notion.Client
         public static readonly ObjectType FileUpload = new ObjectType(FileUploadValue);
         public static readonly ObjectType DataSource = new ObjectType(DataSourceValue);
         public static readonly ObjectType PageMarkdown = new ObjectType(PageMarkdownValue);
+        public static readonly ObjectType View = new ObjectType(ViewValue);
 
         public static implicit operator ObjectType(string value) => new ObjectType(value);
 

--- a/Src/Notion.Client/Models/View/PageReference.cs
+++ b/Src/Notion.Client/Models/View/PageReference.cs
@@ -1,0 +1,13 @@
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public class PageReference
+    {
+        [JsonProperty("object")]
+        public string Object { get; set; }
+
+        [JsonProperty("id")]
+        public string Id { get; set; }
+    }
+}

--- a/Src/Notion.Client/Models/View/View.cs
+++ b/Src/Notion.Client/Models/View/View.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public class View : IObject
+    {
+        public string Id { get; set; }
+
+        public ObjectType Object => ObjectType.View;
+
+        [JsonProperty("type")]
+        public ViewType Type { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("data_source_id")]
+        public string DataSourceId { get; set; }
+
+        [JsonProperty("parent")]
+        public DatabaseParent Parent { get; set; }
+
+        [JsonProperty("created_time")]
+        public DateTime CreatedTime { get; set; }
+
+        [JsonProperty("last_edited_time")]
+        public DateTime LastEditedTime { get; set; }
+
+        [JsonProperty("url")]
+        public string Url { get; set; }
+
+        [JsonProperty("created_by")]
+        public PartialUser CreatedBy { get; set; }
+
+        [JsonProperty("last_edited_by")]
+        public PartialUser LastEditedBy { get; set; }
+
+        [JsonProperty("filter")]
+        public object Filter { get; set; }
+
+        [JsonProperty("sorts")]
+        public IEnumerable<ViewSort> Sorts { get; set; }
+
+        [JsonProperty("configuration")]
+        public ViewConfiguration Configuration { get; set; }
+    }
+}

--- a/Src/Notion.Client/Models/View/ViewConfiguration.cs
+++ b/Src/Notion.Client/Models/View/ViewConfiguration.cs
@@ -1,0 +1,113 @@
+using System.Collections.Generic;
+using JsonSubTypes;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Notion.Client
+{
+    [JsonConverter(typeof(JsonSubtypes), "type")]
+    [JsonSubtypes.KnownSubType(typeof(TableViewConfiguration), ViewType.TableValue)]
+    [JsonSubtypes.KnownSubType(typeof(BoardViewConfiguration), ViewType.BoardValue)]
+    [JsonSubtypes.KnownSubType(typeof(CalendarViewConfiguration), ViewType.CalendarValue)]
+    [JsonSubtypes.KnownSubType(typeof(TimelineViewConfiguration), ViewType.TimelineValue)]
+    [JsonSubtypes.KnownSubType(typeof(GalleryViewConfiguration), ViewType.GalleryValue)]
+    [JsonSubtypes.KnownSubType(typeof(ListViewConfiguration), ViewType.ListValue)]
+    [JsonSubtypes.KnownSubType(typeof(MapViewConfiguration), ViewType.MapValue)]
+    [JsonSubtypes.KnownSubType(typeof(FormViewConfiguration), ViewType.FormValue)]
+    [JsonSubtypes.KnownSubType(typeof(ChartViewConfiguration), ViewType.ChartValue)]
+    [JsonSubtypes.KnownSubType(typeof(DashboardViewConfiguration), ViewType.DashboardValue)]
+    [JsonSubtypes.FallBackSubType(typeof(UnknownViewConfiguration))]
+    public abstract class ViewConfiguration
+    {
+        [JsonProperty("type")]
+        public abstract string Type { get; }
+    }
+
+    public class TableViewConfiguration : ViewConfiguration
+    {
+        public override string Type => ViewType.TableValue;
+
+        [JsonExtensionData]
+        public IDictionary<string, JToken> AdditionalData { get; set; }
+    }
+
+    public class BoardViewConfiguration : ViewConfiguration
+    {
+        public override string Type => ViewType.BoardValue;
+
+        [JsonExtensionData]
+        public IDictionary<string, JToken> AdditionalData { get; set; }
+    }
+
+    public class CalendarViewConfiguration : ViewConfiguration
+    {
+        public override string Type => ViewType.CalendarValue;
+
+        [JsonExtensionData]
+        public IDictionary<string, JToken> AdditionalData { get; set; }
+    }
+
+    public class TimelineViewConfiguration : ViewConfiguration
+    {
+        public override string Type => ViewType.TimelineValue;
+
+        [JsonExtensionData]
+        public IDictionary<string, JToken> AdditionalData { get; set; }
+    }
+
+    public class GalleryViewConfiguration : ViewConfiguration
+    {
+        public override string Type => ViewType.GalleryValue;
+
+        [JsonExtensionData]
+        public IDictionary<string, JToken> AdditionalData { get; set; }
+    }
+
+    public class ListViewConfiguration : ViewConfiguration
+    {
+        public override string Type => ViewType.ListValue;
+
+        [JsonExtensionData]
+        public IDictionary<string, JToken> AdditionalData { get; set; }
+    }
+
+    public class MapViewConfiguration : ViewConfiguration
+    {
+        public override string Type => ViewType.MapValue;
+
+        [JsonExtensionData]
+        public IDictionary<string, JToken> AdditionalData { get; set; }
+    }
+
+    public class FormViewConfiguration : ViewConfiguration
+    {
+        public override string Type => ViewType.FormValue;
+
+        [JsonExtensionData]
+        public IDictionary<string, JToken> AdditionalData { get; set; }
+    }
+
+    public class ChartViewConfiguration : ViewConfiguration
+    {
+        public override string Type => ViewType.ChartValue;
+
+        [JsonExtensionData]
+        public IDictionary<string, JToken> AdditionalData { get; set; }
+    }
+
+    public class DashboardViewConfiguration : ViewConfiguration
+    {
+        public override string Type => ViewType.DashboardValue;
+
+        [JsonExtensionData]
+        public IDictionary<string, JToken> AdditionalData { get; set; }
+    }
+
+    public class UnknownViewConfiguration : ViewConfiguration
+    {
+        public override string Type => "unknown";
+
+        [JsonExtensionData]
+        public IDictionary<string, JToken> AdditionalData { get; set; }
+    }
+}

--- a/Src/Notion.Client/Models/View/ViewSort.cs
+++ b/Src/Notion.Client/Models/View/ViewSort.cs
@@ -1,0 +1,16 @@
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public class ViewSort
+    {
+        [JsonProperty("property")]
+        public string Property { get; set; }
+
+        [JsonProperty("timestamp")]
+        public string Timestamp { get; set; }
+
+        [JsonProperty("direction")]
+        public string Direction { get; set; }
+    }
+}

--- a/Src/Notion.Client/Models/View/ViewType.cs
+++ b/Src/Notion.Client/Models/View/ViewType.cs
@@ -1,0 +1,54 @@
+using System;
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    /// <summary>
+    /// Represents the type of a Notion view.
+    /// New values introduced by Notion are preserved as-is rather than causing a deserialization failure.
+    /// Use the <c>const string</c> members (e.g. <see cref="TableValue"/>) when referencing a value
+    /// in a <c>[JsonSubtypes.KnownSubType]</c> attribute; use the <c>static readonly</c> fields
+    /// (e.g. <see cref="Table"/>) everywhere else.
+    /// </summary>
+    [JsonConverter(typeof(ExtensibleEnumConverter<ViewType>))]
+    public readonly struct ViewType : IEquatable<ViewType>
+    {
+        private readonly string _value;
+
+        public ViewType(string value) => _value = value;
+
+        public const string TableValue = "table";
+        public const string BoardValue = "board";
+        public const string ListValue = "list";
+        public const string CalendarValue = "calendar";
+        public const string TimelineValue = "timeline";
+        public const string GalleryValue = "gallery";
+        public const string FormValue = "form";
+        public const string ChartValue = "chart";
+        public const string MapValue = "map";
+        public const string DashboardValue = "dashboard";
+
+        public static readonly ViewType Table = new ViewType(TableValue);
+        public static readonly ViewType Board = new ViewType(BoardValue);
+        public static readonly ViewType List = new ViewType(ListValue);
+        public static readonly ViewType Calendar = new ViewType(CalendarValue);
+        public static readonly ViewType Timeline = new ViewType(TimelineValue);
+        public static readonly ViewType Gallery = new ViewType(GalleryValue);
+        public static readonly ViewType Form = new ViewType(FormValue);
+        public static readonly ViewType Chart = new ViewType(ChartValue);
+        public static readonly ViewType Map = new ViewType(MapValue);
+        public static readonly ViewType Dashboard = new ViewType(DashboardValue);
+
+        public static implicit operator ViewType(string value) => new ViewType(value);
+
+        public static bool operator ==(ViewType left, ViewType right) => left.Equals(right);
+        public static bool operator !=(ViewType left, ViewType right) => !left.Equals(right);
+
+        public bool Equals(ViewType other) =>
+            string.Equals(_value, other._value, StringComparison.Ordinal);
+
+        public override bool Equals(object obj) => obj is ViewType other && Equals(other);
+        public override int GetHashCode() => _value?.GetHashCode() ?? 0;
+        public override string ToString() => _value ?? string.Empty;
+    }
+}

--- a/Src/Notion.Client/NotionClient.cs
+++ b/Src/Notion.Client/NotionClient.cs
@@ -23,6 +23,8 @@ namespace Notion.Client
 
         IDataSourcesClient DataSources { get; }
 
+        IViewsClient Views { get; }
+
         IRestClient RestClient { get; }
     }
 
@@ -38,7 +40,8 @@ namespace Notion.Client
             IBlocksClient blocks,
             IAuthenticationClient authenticationClient,
             IFileUploadsClient fileUploadsClient,
-            IDataSourcesClient dataSourcesClient)
+            IDataSourcesClient dataSourcesClient,
+            IViewsClient viewsClient)
         {
             RestClient = restClient;
             Users = users;
@@ -50,6 +53,7 @@ namespace Notion.Client
             AuthenticationClient = authenticationClient;
             FileUploads = fileUploadsClient;
             DataSources = dataSourcesClient;
+            Views = viewsClient;
         }
 
         public IAuthenticationClient AuthenticationClient { get; }
@@ -69,6 +73,8 @@ namespace Notion.Client
         public IFileUploadsClient FileUploads { get; }
 
         public IDataSourcesClient DataSources { get; }
+
+        public IViewsClient Views { get; }
 
         public IRestClient RestClient { get; }
     }

--- a/Src/Notion.Client/NotionClientFactory.cs
+++ b/Src/Notion.Client/NotionClientFactory.cs
@@ -17,6 +17,7 @@
                 , new AuthenticationClient(restClient)
                 , new FileUploadsClient(restClient)
                 , new DataSourcesClient(restClient)
+                , new ViewsClient(restClient)
             );
         }
     }

--- a/Src/Notion.Client/RestClient/IRestClient.cs
+++ b/Src/Notion.Client/RestClient/IRestClient.cs
@@ -45,5 +45,12 @@ namespace Notion.Client
             IDictionary<string, string> queryParams = null,
             IDictionary<string, string> headers = null,
             CancellationToken cancellationToken = default);
+
+        Task<T> DeleteAsync<T>(
+            string uri,
+            IDictionary<string, string> queryParams = null,
+            IDictionary<string, string> headers = null,
+            JsonSerializerSettings serializerSettings = null,
+            CancellationToken cancellationToken = default);
     }
 }

--- a/Src/Notion.Client/RestClient/RestClient.cs
+++ b/Src/Notion.Client/RestClient/RestClient.cs
@@ -176,6 +176,19 @@ namespace Notion.Client
                 basicAuthenticationParameters: null, cancellationToken);
         }
 
+        public async Task<T> DeleteAsync<T>(
+            string uri,
+            IDictionary<string, string> queryParams = null,
+            IDictionary<string, string> headers = null,
+            JsonSerializerSettings serializerSettings = null,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await SendAsync(uri, HttpMethod.Delete, queryParams, headers, null,
+                basicAuthenticationParameters: null, cancellationToken);
+
+            return await response.ParseStreamAsync<T>(serializerSettings);
+        }
+
         private static ClientOptions MergeOptions(ClientOptions options)
         {
             return new ClientOptions


### PR DESCRIPTION
Closes #521
Closes #522
Closes #523
Closes #524
Closes #525
Closes #526
Closes #527
Closes #528
Closes #529

## Summary
Implements the complete Views API (8 endpoints):

| Method | Endpoint | SDK method |
|---|---|---|
| GET | `/v1/views` | `Views.ListAsync(ListViewsRequest)` |
| POST | `/v1/views` | `Views.CreateAsync(CreateViewRequest)` |
| GET | `/v1/views/:id` | `Views.RetrieveAsync(viewId)` |
| PATCH | `/v1/views/:id` | `Views.UpdateAsync(UpdateViewRequest)` |
| DELETE | `/v1/views/:id` | `Views.DeleteAsync(viewId)` |
| POST | `/v1/views/:id/queries` | `Views.CreateQueryAsync(CreateViewQueryRequest)` |
| GET | `/v1/views/:id/queries/:qid` | `Views.GetQueryResultsAsync(GetViewQueryResultsRequest)` |
| DELETE | `/v1/views/:id/queries/:qid` | `Views.DeleteQueryAsync(DeleteViewQueryRequest)` |

### New models
- `ViewType` — extensible struct (table, board, list, calendar, timeline, gallery, form, chart, map, dashboard)
- `View` — full response model implementing `IObject`
- `ViewConfiguration` — abstract base with 11 concrete subtypes per view type; each captures type-specific config via `[JsonExtensionData]`
- `ViewSort`, `UpdateViewSort`, `PageReference`, `ViewQueryResponse`, `DeletedViewQueryResponse`

### Other changes
- `ObjectType.View` added to the extensible struct
- `IRestClient`/`RestClient` — adds `DeleteAsync<T>` overload for typed delete responses (used by delete query)
- `INotionClient.Views` — new `IViewsClient` property
- `NotionClientFactory` — wires up `ViewsClient`

## Test plan
- [ ] Build passes
- [ ] `Views.ListAsync` — list views on a data source database
- [ ] `Views.CreateAsync` / `Views.RetrieveAsync` / `Views.UpdateAsync` / `Views.DeleteAsync`
- [ ] `Views.CreateQueryAsync` + `Views.GetQueryResultsAsync` + `Views.DeleteQueryAsync`