### PR TITLE
feat: add typed StatusConfig for status property create/update

### DIFF
--- a/Src/Notion.Client/Models/DataSource/PropertyConfig/StatusDataSourcePropertyConfig.cs
+++ b/Src/Notion.Client/Models/DataSource/PropertyConfig/StatusDataSourcePropertyConfig.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Notion.Client
@@ -8,6 +8,45 @@ namespace Notion.Client
         public override string Type => DataSourcePropertyTypes.Status;
 
         [JsonProperty("status")]
-        public Dictionary<string, object> Status { get; set; }
+        public StatusConfig Status { get; set; }
+    }
+
+    public class StatusConfig
+    {
+        [JsonProperty("options")]
+        public IEnumerable<StatusOption> Options { get; set; }
+
+        [JsonProperty("groups")]
+        public IEnumerable<StatusGroup> Groups { get; set; }
+
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalData { get; set; }
+    }
+
+    public class StatusOption
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("color")]
+        public Color? Color { get; set; }
+    }
+
+    public class StatusGroup
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("color")]
+        public Color? Color { get; set; }
+
+        [JsonProperty("option_ids")]
+        public IEnumerable<string> OptionIds { get; set; }
     }
 }

--- a/Src/Notion.Client/Models/DataSource/Request/PropertyConfig/StatusDataSourcePropertyConfigRequest.cs
+++ b/Src/Notion.Client/Models/DataSource/Request/PropertyConfig/StatusDataSourcePropertyConfigRequest.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Notion.Client
@@ -9,6 +9,59 @@ namespace Notion.Client
         public override string Type => "status";
 
         [JsonProperty("status")]
-        public IDictionary<string, object> Status { get; set; }
+        public StatusConfigRequest Status { get; set; }
+    }
+
+    public class StatusConfigRequest
+    {
+        /// <summary>
+        /// The available status options. Each option must have a name; id and color are optional.
+        /// </summary>
+        [JsonProperty("options")]
+        public IEnumerable<StatusOptionRequest> Options { get; set; }
+
+        /// <summary>
+        /// Groups that organise the status options. Each group references option IDs.
+        /// </summary>
+        [JsonProperty("groups")]
+        public IEnumerable<StatusGroupRequest> Groups { get; set; }
+    }
+
+    public class StatusOptionRequest
+    {
+        /// <summary>
+        /// ID of an existing option to update. Omit when creating a new option.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>Name of the status option.</summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>Color of the status option.</summary>
+        [JsonProperty("color")]
+        public Color? Color { get; set; }
+    }
+
+    public class StatusGroupRequest
+    {
+        /// <summary>
+        /// ID of an existing group to update. Omit when creating a new group.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>Name of the group.</summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>Color of the group.</summary>
+        [JsonProperty("color")]
+        public Color? Color { get; set; }
+
+        /// <summary>IDs of the status options that belong to this group.</summary>
+        [JsonProperty("option_ids")]
+        public IEnumerable<string> OptionIds { get; set; }
     }
 }

--- a/Src/Notion.Client/Models/Database/Properties/StatusProperty.cs
+++ b/Src/Notion.Client/Models/Database/Properties/StatusProperty.cs
@@ -1,4 +1,3 @@
-﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Notion.Client
@@ -8,6 +7,6 @@ namespace Notion.Client
         public override PropertyType Type => PropertyType.Status;
 
         [JsonProperty("status")]
-        public Dictionary<string, object> Status { get; set; }
+        public StatusConfig Status { get; set; }
     }
 }


### PR DESCRIPTION
Closes #530

## Summary
Replaces the opaque `Dictionary<string, object>` in status property models with properly typed classes, making it possible to create and update status properties with explicit options and groups.

### New models
- `StatusConfig` — response shape: `Options` + `Groups` + `AdditionalData` (forward-compat)
- `StatusOption` — `Id`, `Name`, `Color`
- `StatusGroup` — `Id`, `Name`, `Color`, `OptionIds`
- `StatusConfigRequest` — request shape for create/update
- `StatusOptionRequest` / `StatusGroupRequest` — writable request variants

### Updated
- `StatusProperty` (database schema response) — now uses `StatusConfig`
- `StatusDataSourcePropertyConfig` — now uses `StatusConfig`
- `StatusDataSourcePropertyConfigRequest` — now uses `StatusConfigRequest`

## Test plan
- [ ] Create a data source with a status property specifying options and groups
- [ ] Update status property options via `UpdateDataSourceRequest`
- [ ] Retrieve status property and verify `StatusConfig` deserializes correctly