### PR TITLE
feat: add List custom emojis API (#532)

### DIFF
--- a/Src/Notion.Client/Api/ApiEndpoints.cs
+++ b/Src/Notion.Client/Api/ApiEndpoints.cs
@@ -152,5 +152,10 @@
             internal static string ListDataSourceTemplates(IListDataSourceTemplatesPathParameters pathParameters) => $"/v1/data_sources/{pathParameters.DataSourceId}/templates";
             internal static string Query(IQueryDataSourcePathParameters pathParameters) => $"{BasePath}/{pathParameters.DataSourceId}/query";
         }
+
+        public static class EmojisApiUrls
+        {
+            public static string List => "/v1/custom_emojis";
+        }
     }
 }

--- a/Src/Notion.Client/Api/Emojis/EmojisClient.cs
+++ b/Src/Notion.Client/Api/Emojis/EmojisClient.cs
@@ -1,0 +1,12 @@
+namespace Notion.Client
+{
+    public sealed partial class EmojisClient : IEmojisClient
+    {
+        private readonly IRestClient _restClient;
+
+        public EmojisClient(IRestClient restClient)
+        {
+            _restClient = restClient;
+        }
+    }
+}

--- a/Src/Notion.Client/Api/Emojis/IEmojisClient.cs
+++ b/Src/Notion.Client/Api/Emojis/IEmojisClient.cs
@@ -1,0 +1,19 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Notion.Client
+{
+    public interface IEmojisClient
+    {
+        /// <summary>
+        /// List all custom emojis available in the workspace.
+        /// </summary>
+        /// <param name="request">Pagination parameters.</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>A paginated list of custom emojis.</returns>
+        Task<ListEmojisResponse> ListAsync(
+            ListEmojisRequest request,
+            CancellationToken cancellationToken = default
+        );
+    }
+}

--- a/Src/Notion.Client/Api/Emojis/List/EmojisClient.cs
+++ b/Src/Notion.Client/Api/Emojis/List/EmojisClient.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Notion.Client
+{
+    public sealed partial class EmojisClient
+    {
+        public async Task<ListEmojisResponse> ListAsync(
+            ListEmojisRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            IListEmojisQueryParameters queryParameters = request;
+
+            var queryParams = new Dictionary<string, string>
+            {
+                { "start_cursor", queryParameters.StartCursor },
+                { "page_size", queryParameters.PageSize?.ToString() }
+            };
+
+            return await _restClient.GetAsync<ListEmojisResponse>(
+                ApiEndpoints.EmojisApiUrls.List,
+                queryParams: queryParams,
+                cancellationToken: cancellationToken
+            );
+        }
+    }
+}

--- a/Src/Notion.Client/Api/Emojis/List/Request/IListEmojisQueryParameters.cs
+++ b/Src/Notion.Client/Api/Emojis/List/Request/IListEmojisQueryParameters.cs
@@ -1,0 +1,6 @@
+namespace Notion.Client
+{
+    public interface IListEmojisQueryParameters : IPaginationParameters
+    {
+    }
+}

--- a/Src/Notion.Client/Api/Emojis/List/Request/ListEmojisRequest.cs
+++ b/Src/Notion.Client/Api/Emojis/List/Request/ListEmojisRequest.cs
@@ -1,0 +1,9 @@
+namespace Notion.Client
+{
+    public class ListEmojisRequest : IListEmojisQueryParameters
+    {
+        public string StartCursor { get; set; }
+
+        public int? PageSize { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Emojis/List/Response/ListEmojisResponse.cs
+++ b/Src/Notion.Client/Api/Emojis/List/Response/ListEmojisResponse.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public class ListEmojisResponse : PaginatedList<CustomEmoji>
+    {
+        [JsonProperty("custom_emoji")]
+        public Dictionary<string, object> CustomEmoji { get; set; }
+    }
+}

--- a/Src/Notion.Client/NotionClient.cs
+++ b/Src/Notion.Client/NotionClient.cs
@@ -23,6 +23,8 @@ namespace Notion.Client
 
         IDataSourcesClient DataSources { get; }
 
+        IEmojisClient Emojis { get; }
+
         IRestClient RestClient { get; }
     }
 
@@ -38,7 +40,8 @@ namespace Notion.Client
             IBlocksClient blocks,
             IAuthenticationClient authenticationClient,
             IFileUploadsClient fileUploadsClient,
-            IDataSourcesClient dataSourcesClient)
+            IDataSourcesClient dataSourcesClient,
+            IEmojisClient emojisClient)
         {
             RestClient = restClient;
             Users = users;
@@ -50,6 +53,7 @@ namespace Notion.Client
             AuthenticationClient = authenticationClient;
             FileUploads = fileUploadsClient;
             DataSources = dataSourcesClient;
+            Emojis = emojisClient;
         }
 
         public IAuthenticationClient AuthenticationClient { get; }
@@ -69,6 +73,8 @@ namespace Notion.Client
         public IFileUploadsClient FileUploads { get; }
 
         public IDataSourcesClient DataSources { get; }
+
+        public IEmojisClient Emojis { get; }
 
         public IRestClient RestClient { get; }
     }

--- a/Src/Notion.Client/NotionClientFactory.cs
+++ b/Src/Notion.Client/NotionClientFactory.cs
@@ -17,6 +17,7 @@
                 , new AuthenticationClient(restClient)
                 , new FileUploadsClient(restClient)
                 , new DataSourcesClient(restClient)
+                , new EmojisClient(restClient)
             );
         }
     }


### PR DESCRIPTION
## Summary

- Adds `IEmojisClient` with `ListAsync` method calling `GET /v1/custom_emojis`
- Follows the same paginated list pattern as `FileUploadsClient` and `UsersClient`
- Reuses the existing `CustomEmoji` model from `Models/Page/PageIcon/CustomEmoji.cs`
- Registers `EmojisClient` in `NotionClientFactory` and exposes `INotionClient.Emojis`

Closes #532

## Test plan
- [ ] Build passes with no warnings
- [ ] Unit tests pass (141 total, 0 failures)
- [ ] Manually verify `client.Emojis.ListAsync(new ListEmojisRequest())` returns custom emojis from the workspace