### PR TITLE
feat: make verification property writable (#533)

### DIFF
--- a/Src/Notion.Client/Models/Filters/VerificationStatus.cs
+++ b/Src/Notion.Client/Models/Filters/VerificationStatus.cs
@@ -15,10 +15,12 @@ namespace Notion.Client
         public VerificationStatus(string value) => _value = value;
 
         public const string VerifiedValue = "verified";
+        public const string UnverifiedValue = "unverified";
         public const string ExpiredValue = "expired";
         public const string NoneValue = "none";
 
         public static readonly VerificationStatus Verified = new VerificationStatus(VerifiedValue);
+        public static readonly VerificationStatus Unverified = new VerificationStatus(UnverifiedValue);
         public static readonly VerificationStatus Expired = new VerificationStatus(ExpiredValue);
         public static readonly VerificationStatus None = new VerificationStatus(NoneValue);
 

--- a/Src/Notion.Client/Models/PropertyValue/VerificationPropertyValue.cs
+++ b/Src/Notion.Client/Models/PropertyValue/VerificationPropertyValue.cs
@@ -18,10 +18,12 @@ namespace Notion.Client
         public class Info
         {
             /// <summary>
-            ///     The state of verification. Possible values are "verified" and "unverified".
+            ///     The state of verification.
+            ///     Read values: <see cref="VerificationStatus.Verified"/>, <see cref="VerificationStatus.Expired"/>, <see cref="VerificationStatus.None"/>.
+            ///     Write values: <see cref="VerificationStatus.Verified"/>, <see cref="VerificationStatus.Unverified"/>.
             /// </summary>
             [JsonProperty("state")]
-            public string State { get; set; }
+            public VerificationStatus State { get; set; }
 
             /// <summary>
             ///     Describes the user who verified this page.


### PR DESCRIPTION
## Summary

- Adds `VerificationStatus.Unverified` (`"unverified"`) — the write-time value to clear verification
- Changes `VerificationPropertyValue.Info.State` from `string` to `VerificationStatus` for type safety

Allows setting/clearing page verification via `PagesCreateParameters` or `PagesUpdateParameters`:

```csharp
Properties = new Dictionary<string, PropertyValue>
{
    ["Verification"] = new VerificationPropertyValue
    {
        Verification = new VerificationPropertyValue.Info
        {
            State = VerificationStatus.Verified,
            Date = new Date { Start = DateTimeOffset.UtcNow.AddDays(30) }
        }
    }
}
```

Closes #533

## Test plan
- [ ] Build passes with no warnings
- [ ] Unit tests pass (141 total, 0 failures)
- [ ] Manually verify setting `State = VerificationStatus.Verified` on a wiki database page works via the API
- [ ] Manually verify setting `State = VerificationStatus.Unverified` clears verification