### PR TITLE
feat: add Tab block support (#534)

### DIFF
--- a/Src/Notion.Client/Models/Blocks/BlockType.cs
+++ b/Src/Notion.Client/Models/Blocks/BlockType.cs
@@ -54,6 +54,7 @@ namespace Notion.Client
 
         [Obsolete("Use MeetingNotesValue instead. 'transcription' was renamed to 'meeting_notes' in Notion API version 2026-03-11.")]
         public const string TranscriptionValue = "transcription";
+        public const string TabValue = "tab";
 
         public static readonly BlockType Paragraph = new BlockType(ParagraphValue);
         public static readonly BlockType Heading1 = new BlockType(Heading1Value);
@@ -94,6 +95,8 @@ namespace Notion.Client
         [Obsolete("Use MeetingNotes instead. 'transcription' was renamed to 'meeting_notes' in Notion API version 2026-03-11.")]
         public static readonly BlockType Transcription = new BlockType(TranscriptionValue);
 #pragma warning restore CS0618
+
+        public static readonly BlockType Tab = new BlockType(TabValue);
 
         public static implicit operator BlockType(string value) => new BlockType(value);
 

--- a/Src/Notion.Client/Models/Blocks/IBlock.cs
+++ b/Src/Notion.Client/Models/Blocks/IBlock.cs
@@ -37,6 +37,7 @@ namespace Notion.Client
     [JsonSubtypes.KnownSubTypeAttribute(typeof(ToDoBlock), BlockType.ToDoValue)]
     [JsonSubtypes.KnownSubTypeAttribute(typeof(ToggleBlock), BlockType.ToggleValue)]
     [JsonSubtypes.KnownSubTypeAttribute(typeof(VideoBlock), BlockType.VideoValue)]
+    [JsonSubtypes.KnownSubTypeAttribute(typeof(TabBlock), BlockType.TabValue)]
     [JsonSubtypes.KnownSubTypeAttribute(typeof(UnsupportedBlock), BlockType.UnsupportedValue)]
     [JsonSubtypes.KnownSubTypeAttribute(typeof(MeetingNotesBlock), BlockType.MeetingNotesValue)]
 #pragma warning disable CS0618

--- a/Src/Notion.Client/Models/Blocks/Request/TabBlockRequest.cs
+++ b/Src/Notion.Client/Models/Blocks/Request/TabBlockRequest.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public class TabBlockRequest : BlockObjectRequest, IColumnChildrenBlockRequest, INonColumnBlockRequest
+    {
+        public override BlockType Type => BlockType.Tab;
+
+        [JsonProperty("tab")]
+        public Data Tab { get; set; }
+
+        public class Data
+        {
+            /// <summary>
+            /// Paragraph blocks that represent individual tabs. Only paragraph blocks are valid children.
+            /// </summary>
+            [JsonProperty("children")]
+            public IEnumerable<ParagraphBlockRequest> Children { get; set; }
+        }
+    }
+}

--- a/Src/Notion.Client/Models/Blocks/TabBlock.cs
+++ b/Src/Notion.Client/Models/Blocks/TabBlock.cs
@@ -1,0 +1,16 @@
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public class TabBlock : Block, IColumnChildrenBlock, INonColumnBlock
+    {
+        public override BlockType Type => BlockType.Tab;
+
+        [JsonProperty("tab")]
+        public Data Tab { get; set; }
+
+        public class Data
+        {
+        }
+    }
+}

--- a/Test/Notion.IntegrationTests/BlocksClientTests.cs
+++ b/Test/Notion.IntegrationTests/BlocksClientTests.cs
@@ -167,6 +167,56 @@ public class IBlocksClientTests : IntegrationTestBase, IAsyncLifetime
         blocks.Results.Should().HaveCount(2);
     }
 
+    [Fact]
+    public async Task AppendChildrenAsync_WithTabBlock_AppendsTabBlock()
+    {
+        // Arrange & Act
+        var blocks = await Client.Blocks.AppendChildrenAsync(
+            new BlockAppendChildrenRequest
+            {
+                BlockId = _page.Id,
+                Children = new List<IBlockObjectRequest>
+                {
+                    new TabBlockRequest
+                    {
+                        Tab = new TabBlockRequest.Data
+                        {
+                            Children = new List<ParagraphBlockRequest>
+                            {
+                                new ParagraphBlockRequest
+                                {
+                                    Paragraph = new ParagraphBlockRequest.Info
+                                    {
+                                        RichText = new List<RichTextBaseInput>
+                                        {
+                                            new RichTextTextInput { Text = new Text { Content = "Tab 1" } }
+                                        }
+                                    }
+                                },
+                                new ParagraphBlockRequest
+                                {
+                                    Paragraph = new ParagraphBlockRequest.Info
+                                    {
+                                        RichText = new List<RichTextBaseInput>
+                                        {
+                                            new RichTextTextInput { Text = new Text { Content = "Tab 2" } }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        );
+
+        // Assert
+        var block = blocks.Results.Should().ContainSingle().Subject;
+        block.Should().BeOfType<TabBlock>();
+        block.Type.Should().Be(BlockType.Tab);
+        block.HasChildren.Should().BeTrue();
+    }
+
     [Theory]
     [MemberData(nameof(BlockData))]
     public async Task UpdateAsync_UpdatesGivenBlock(


### PR DESCRIPTION
## Summary

- Adds `BlockType.Tab` (`"tab"`) to the extensible struct
- Adds `TabBlock` (read model) — deserializes tab blocks with empty `tab: {}` data
- Adds `TabBlockRequest` (write model) — creates tab blocks with optional inline paragraph children
- Registers `TabBlock` in `IBlock` polymorphic discriminator so tab blocks are correctly deserialized

Closes #534

## Test plan
- [ ] Build passes with no warnings
- [ ] Unit tests pass
- [ ] Manually verify that retrieving a page with tab blocks deserializes them as `TabBlock`
- [ ] Manually verify that appending a `TabBlockRequest` with paragraph children creates a tab block