### PR TITLE
feat: add relative date filter values for DateFilter (#535)

### DIFF
--- a/Src/Notion.Client/Models/Filters/DateFilter.cs
+++ b/Src/Notion.Client/Models/Filters/DateFilter.cs
@@ -1,7 +1,5 @@
-﻿using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 
 namespace Notion.Client
 {
@@ -9,11 +7,11 @@ namespace Notion.Client
     {
         public DateFilter(
             string propertyName,
-            DateTime? equal = null,
-            DateTime? before = null,
-            DateTime? after = null,
-            DateTime? onOrBefore = null,
-            DateTime? onOrAfter = null,
+            RelativeDateValue? equal = null,
+            RelativeDateValue? before = null,
+            RelativeDateValue? after = null,
+            RelativeDateValue? onOrBefore = null,
+            RelativeDateValue? onOrAfter = null,
             Dictionary<string, object> pastWeek = null,
             Dictionary<string, object> pastMonth = null,
             Dictionary<string, object> pastYear = null,
@@ -48,11 +46,11 @@ namespace Notion.Client
         public class Condition
         {
             public Condition(
-                DateTime? equal = null,
-                DateTime? before = null,
-                DateTime? after = null,
-                DateTime? onOrBefore = null,
-                DateTime? onOrAfter = null,
+                RelativeDateValue? equal = null,
+                RelativeDateValue? before = null,
+                RelativeDateValue? after = null,
+                RelativeDateValue? onOrBefore = null,
+                RelativeDateValue? onOrAfter = null,
                 Dictionary<string, object> pastWeek = null,
                 Dictionary<string, object> pastMonth = null,
                 Dictionary<string, object> pastYear = null,
@@ -78,24 +76,19 @@ namespace Notion.Client
             }
 
             [JsonProperty("equals")]
-            [JsonConverter(typeof(IsoDateTimeConverter))]
-            public DateTime? Equal { get; set; }
+            public RelativeDateValue? Equal { get; set; }
 
             [JsonProperty("before")]
-            [JsonConverter(typeof(IsoDateTimeConverter))]
-            public DateTime? Before { get; set; }
+            public RelativeDateValue? Before { get; set; }
 
             [JsonProperty("after")]
-            [JsonConverter(typeof(IsoDateTimeConverter))]
-            public DateTime? After { get; set; }
+            public RelativeDateValue? After { get; set; }
 
             [JsonProperty("on_or_before")]
-            [JsonConverter(typeof(IsoDateTimeConverter))]
-            public DateTime? OnOrBefore { get; set; }
+            public RelativeDateValue? OnOrBefore { get; set; }
 
             [JsonProperty("on_or_after")]
-            [JsonConverter(typeof(IsoDateTimeConverter))]
-            public DateTime? OnOrAfter { get; set; }
+            public RelativeDateValue? OnOrAfter { get; set; }
 
             [JsonProperty("past_week")]
             public Dictionary<string, object> PastWeek { get; set; }

--- a/Src/Notion.Client/Models/Filters/RelativeDateValue.cs
+++ b/Src/Notion.Client/Models/Filters/RelativeDateValue.cs
@@ -1,0 +1,60 @@
+using System;
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    /// <summary>
+    /// Represents a date filter value that can be either an ISO 8601 date string or a relative date keyword.
+    /// Relative keywords are resolved at query time relative to the current date.
+    /// </summary>
+    [JsonConverter(typeof(ExtensibleEnumConverter<RelativeDateValue>))]
+    public readonly struct RelativeDateValue : IEquatable<RelativeDateValue>
+    {
+        private readonly string _value;
+
+        public RelativeDateValue(string value) => _value = value;
+
+        public const string TodayValue = "today";
+        public const string TomorrowValue = "tomorrow";
+        public const string YesterdayValue = "yesterday";
+        public const string OneWeekAgoValue = "one_week_ago";
+        public const string OneWeekFromNowValue = "one_week_from_now";
+        public const string OneMonthAgoValue = "one_month_ago";
+        public const string OneMonthFromNowValue = "one_month_from_now";
+
+        public static readonly RelativeDateValue Today = new RelativeDateValue(TodayValue);
+        public static readonly RelativeDateValue Tomorrow = new RelativeDateValue(TomorrowValue);
+        public static readonly RelativeDateValue Yesterday = new RelativeDateValue(YesterdayValue);
+        public static readonly RelativeDateValue OneWeekAgo = new RelativeDateValue(OneWeekAgoValue);
+        public static readonly RelativeDateValue OneWeekFromNow = new RelativeDateValue(OneWeekFromNowValue);
+        public static readonly RelativeDateValue OneMonthAgo = new RelativeDateValue(OneMonthAgoValue);
+        public static readonly RelativeDateValue OneMonthFromNow = new RelativeDateValue(OneMonthFromNowValue);
+
+        public static implicit operator RelativeDateValue(string value) => new RelativeDateValue(value);
+
+        public static implicit operator RelativeDateValue(DateTime value)
+        {
+            string formatted;
+            if (value.Kind == DateTimeKind.Utc)
+                formatted = value.ToString("yyyy-MM-ddTHH:mm:ssZ");
+            else if (value.Kind == DateTimeKind.Local)
+                formatted = value.ToString("yyyy-MM-ddTHH:mm:sszzz");
+            else
+                formatted = value.ToString("yyyy-MM-ddTHH:mm:ss");
+            return new RelativeDateValue(formatted);
+        }
+
+        public static implicit operator RelativeDateValue(DateTimeOffset value)
+            => new RelativeDateValue(value.ToString("yyyy-MM-ddTHH:mm:sszzz"));
+
+        public static bool operator ==(RelativeDateValue left, RelativeDateValue right) => left.Equals(right);
+        public static bool operator !=(RelativeDateValue left, RelativeDateValue right) => !left.Equals(right);
+
+        public bool Equals(RelativeDateValue other) =>
+            string.Equals(_value, other._value, StringComparison.Ordinal);
+
+        public override bool Equals(object obj) => obj is RelativeDateValue other && Equals(other);
+        public override int GetHashCode() => _value?.GetHashCode() ?? 0;
+        public override string ToString() => _value ?? string.Empty;
+    }
+}

--- a/Test/Notion.UnitTests/FilterTests.cs
+++ b/Test/Notion.UnitTests/FilterTests.cs
@@ -56,12 +56,91 @@ public class FilterTests
     }
 
     [Fact]
-    public void DateFilterTest()
+    public void DateFilterTest_WithDateTime_UnspecifiedKind()
     {
         var filter = new DateFilter("When", onOrAfter: new DateTime(2042, 11, 29));
 
         Assert.Equal(
             "{\"date\":{\"on_or_after\":\"2042-11-29T00:00:00\"},\"property\":\"When\"}",
+            SerializeFilter(filter)
+        );
+    }
+
+    [Fact]
+    public void DateFilterTest_WithDateTime_UtcKind()
+    {
+        var filter = new DateFilter("When", after: new DateTime(2042, 11, 29, 10, 30, 0, DateTimeKind.Utc));
+
+        Assert.Equal(
+            "{\"date\":{\"after\":\"2042-11-29T10:30:00Z\"},\"property\":\"When\"}",
+            SerializeFilter(filter)
+        );
+    }
+
+    [Fact]
+    public void DateFilterTest_WithDateTimeOffset()
+    {
+        var offset = new DateTimeOffset(2042, 11, 29, 10, 30, 0, TimeSpan.FromHours(5));
+        var filter = new DateFilter("When", before: offset);
+
+        Assert.Equal(
+            "{\"date\":{\"before\":\"2042-11-29T10:30:00+05:00\"},\"property\":\"When\"}",
+            SerializeFilter(filter)
+        );
+    }
+
+    [Fact]
+    public void DateFilterTest_WithRelativeDateKeyword_Today()
+    {
+        var filter = new DateFilter("Due", onOrAfter: RelativeDateValue.Today);
+
+        Assert.Equal(
+            "{\"date\":{\"on_or_after\":\"today\"},\"property\":\"Due\"}",
+            SerializeFilter(filter)
+        );
+    }
+
+    [Fact]
+    public void DateFilterTest_WithRelativeDateKeyword_Tomorrow()
+    {
+        var filter = new DateFilter("Due", before: RelativeDateValue.Tomorrow);
+
+        Assert.Equal(
+            "{\"date\":{\"before\":\"tomorrow\"},\"property\":\"Due\"}",
+            SerializeFilter(filter)
+        );
+    }
+
+    [Fact]
+    public void DateFilterTest_WithRelativeDateKeyword_OneWeekFromNow()
+    {
+        var filter = new DateFilter("Due", onOrBefore: RelativeDateValue.OneWeekFromNow);
+
+        Assert.Equal(
+            "{\"date\":{\"on_or_before\":\"one_week_from_now\"},\"property\":\"Due\"}",
+            SerializeFilter(filter)
+        );
+    }
+
+    [Fact]
+    public void DateFilterTest_WithRelativeDateKeyword_OneMonthAgo()
+    {
+        var filter = new DateFilter("Modified", equal: RelativeDateValue.OneMonthAgo);
+
+        Assert.Equal(
+            "{\"date\":{\"equals\":\"one_month_ago\"},\"property\":\"Modified\"}",
+            SerializeFilter(filter)
+        );
+    }
+
+    [Fact]
+    public void DateFilterTest_WithRelativeDateKeyword_CustomString()
+    {
+        RelativeDateValue custom = "yesterday";
+        var filter = new DateFilter("Due", after: custom);
+
+        Assert.Equal(
+            "{\"date\":{\"after\":\"yesterday\"},\"property\":\"Due\"}",
             SerializeFilter(filter)
         );
     }


### PR DESCRIPTION
## Summary

- Adds `RelativeDateValue` struct with constants: `Today`, `Tomorrow`, `Yesterday`, `OneWeekAgo`, `OneWeekFromNow`, `OneMonthAgo`, `OneMonthFromNow`
- Changes `DateFilter.Condition` date fields (`Equal`, `Before`, `After`, `OnOrBefore`, `OnOrAfter`) from `DateTime?` to `RelativeDateValue?`
- `RelativeDateValue` has implicit conversions from `string`, `DateTime`, and `DateTimeOffset` — existing code continues to compile

**Breaking change**: `DateFilter` constructor and `Condition` property types change. Existing `DateTime` usage continues to work via implicit conversion. Existing `DateTime?` variables (not literals) assigned to these fields will also continue to work via nullable lifting of the implicit operator.

Closes #535

## Test plan
- [ ] Build passes with no warnings
- [ ] Unit tests pass (141 total — `DateFilterTest` still serializes `DateTime` correctly)
- [ ] Manually verify `DateFilter("date", equal: RelativeDateValue.Today)` works in a database query
- [ ] Manually verify existing `DateFilter("date", equal: new DateTime(2024, 1, 1))` still works