### PR TITLE
feat: add optional icon field to ParagraphBlock for tab items (#536)

### DIFF
--- a/Src/Notion.Client/Models/Blocks/ParagraphBlock.cs
+++ b/Src/Notion.Client/Models/Blocks/ParagraphBlock.cs
@@ -20,6 +20,13 @@ namespace Notion.Client
 
             [JsonProperty("children")]
             public IEnumerable<INonColumnBlock> Children { get; set; }
+
+            /// <summary>
+            /// Optional icon for paragraph blocks that are direct children of a tab block.
+            /// Setting an icon on other paragraphs results in a validation error from the API.
+            /// </summary>
+            [JsonProperty("icon")]
+            public IPageIcon Icon { get; set; }
         }
     }
 }

--- a/Src/Notion.Client/Models/Blocks/Request/ParagraphBlockRequest.cs
+++ b/Src/Notion.Client/Models/Blocks/Request/ParagraphBlockRequest.cs
@@ -20,6 +20,13 @@ namespace Notion.Client
 
             [JsonProperty("children")]
             public IEnumerable<INonColumnBlockRequest> Children { get; set; }
+
+            /// <summary>
+            /// Optional icon for paragraph blocks that are direct children of a tab block.
+            /// Setting an icon on other paragraphs results in a validation error from the API.
+            /// </summary>
+            [JsonProperty("icon")]
+            public IPageIconRequest Icon { get; set; }
         }
     }
 }

--- a/Test/Notion.IntegrationTests/BlocksClientTests.cs
+++ b/Test/Notion.IntegrationTests/BlocksClientTests.cs
@@ -217,6 +217,52 @@ public class IBlocksClientTests : IntegrationTestBase, IAsyncLifetime
         block.HasChildren.Should().BeTrue();
     }
 
+    [Fact]
+    public async Task AppendChildrenAsync_WithTabBlockAndParagraphIcon_ParagraphIconIsReturned()
+    {
+        // Act — create a tab block whose paragraph children have emoji icons
+        var blocks = await Client.Blocks.AppendChildrenAsync(
+            new BlockAppendChildrenRequest
+            {
+                BlockId = _page.Id,
+                Children = new List<IBlockObjectRequest>
+                {
+                    new TabBlockRequest
+                    {
+                        Tab = new TabBlockRequest.Data
+                        {
+                            Children = new List<ParagraphBlockRequest>
+                            {
+                                new ParagraphBlockRequest
+                                {
+                                    Paragraph = new ParagraphBlockRequest.Info
+                                    {
+                                        RichText = new List<RichTextBaseInput>
+                                        {
+                                            new RichTextTextInput { Text = new Text { Content = "Tab with icon" } }
+                                        },
+                                        Icon = new EmojiPageIconRequest { Emoji = "🎯" }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        );
+
+        // Assert — retrieve children of the tab block and verify the paragraph has an icon
+        var tabBlock = blocks.Results.Should().ContainSingle().Subject.Should().BeOfType<TabBlock>().Subject;
+
+        var tabChildren = await Client.Blocks.RetrieveChildrenAsync(
+            new BlockRetrieveChildrenRequest { BlockId = tabBlock.Id });
+
+        var paragraph = tabChildren.Results.Should().ContainSingle().Subject.Should().BeOfType<ParagraphBlock>().Subject;
+        paragraph.Paragraph.Icon.Should().NotBeNull();
+        paragraph.Paragraph.Icon.Should().BeOfType<EmojiPageIcon>();
+        ((EmojiPageIcon)paragraph.Paragraph.Icon).Emoji.Should().Be("🎯");
+    }
+
     [Theory]
     [MemberData(nameof(BlockData))]
     public async Task UpdateAsync_UpdatesGivenBlock(


### PR DESCRIPTION
## Summary

- Adds `Icon` (`IPageIcon`) to `ParagraphBlock.Info` for reading icon from tab paragraph children
- Adds `Icon` (`IPageIconRequest`) to `ParagraphBlockRequest.Info` for setting icon when creating/updating tab paragraph children

> Note: The Notion API rejects icons on paragraph blocks that are not direct children of a tab block with a validation error.

Closes #536

## Test plan
- [ ] Build passes with no warnings
- [ ] Unit tests pass
- [ ] Manually verify setting `Icon = new EmojiPageIcon { Emoji = "🌟" }` on a `ParagraphBlockRequest` within a `TabBlockRequest.Data.Children` creates a tab with the icon
- [ ] Manually verify retrieving tab children deserializes the icon correctly