### PR TITLE
feat: add Heading 4 block type (#537)

### DIFF
--- a/Src/Notion.Client/Api/Blocks/RequestParams/BlocksUpdateParameters/UpdateBlocks/HeadingFourUpdateBlock.cs
+++ b/Src/Notion.Client/Api/Blocks/RequestParams/BlocksUpdateParameters/UpdateBlocks/HeadingFourUpdateBlock.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public class HeadingFourUpdateBlock : UpdateBlock
+    {
+        [JsonProperty("heading_4")]
+        [SuppressMessage("ReSharper", "InconsistentNaming")]
+        public Info Heading_4 { get; set; }
+
+        public class Info
+        {
+            [JsonProperty("rich_text")]
+            public IEnumerable<RichTextBaseInput> RichText { get; set; }
+        }
+    }
+}

--- a/Src/Notion.Client/Models/Blocks/BlockType.cs
+++ b/Src/Notion.Client/Models/Blocks/BlockType.cs
@@ -21,6 +21,7 @@ namespace Notion.Client
         public const string Heading1Value = "heading_1";
         public const string Heading2Value = "heading_2";
         public const string Heading3Value = "heading_3";
+        public const string Heading4Value = "heading_4";
         public const string BulletedListItemValue = "bulleted_list_item";
         public const string NumberedListItemValue = "numbered_list_item";
         public const string ToDoValue = "to_do";
@@ -60,6 +61,7 @@ namespace Notion.Client
         public static readonly BlockType Heading1 = new BlockType(Heading1Value);
         public static readonly BlockType Heading2 = new BlockType(Heading2Value);
         public static readonly BlockType Heading3 = new BlockType(Heading3Value);
+        public static readonly BlockType Heading4 = new BlockType(Heading4Value);
         public static readonly BlockType BulletedListItem = new BlockType(BulletedListItemValue);
         public static readonly BlockType NumberedListItem = new BlockType(NumberedListItemValue);
         public static readonly BlockType ToDo = new BlockType(ToDoValue);

--- a/Src/Notion.Client/Models/Blocks/HeadingFourBlock.cs
+++ b/Src/Notion.Client/Models/Blocks/HeadingFourBlock.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public class HeadingFourBlock : Block, IColumnChildrenBlock, INonColumnBlock
+    {
+        [JsonProperty("heading_4")]
+        [SuppressMessage("ReSharper", "InconsistentNaming")]
+        public Info Heading_4 { get; set; }
+
+        public override BlockType Type => BlockType.Heading4;
+
+        public class Info
+        {
+            [JsonProperty("rich_text")]
+            public IEnumerable<RichTextBase> RichText { get; set; }
+
+            [JsonProperty("color")]
+            public Color? Color { get; set; }
+
+            [JsonProperty("is_toggleable")]
+            public bool IsToggleable { get; set; }
+        }
+    }
+}

--- a/Src/Notion.Client/Models/Blocks/IBlock.cs
+++ b/Src/Notion.Client/Models/Blocks/IBlock.cs
@@ -22,6 +22,7 @@ namespace Notion.Client
     [JsonSubtypes.KnownSubTypeAttribute(typeof(HeadingOneBlock), BlockType.Heading1Value)]
     [JsonSubtypes.KnownSubTypeAttribute(typeof(HeadingTwoBlock), BlockType.Heading2Value)]
     [JsonSubtypes.KnownSubTypeAttribute(typeof(HeadingThreeBlock), BlockType.Heading3Value)]
+    [JsonSubtypes.KnownSubTypeAttribute(typeof(HeadingFourBlock), BlockType.Heading4Value)]
     [JsonSubtypes.KnownSubTypeAttribute(typeof(ImageBlock), BlockType.ImageValue)]
     [JsonSubtypes.KnownSubTypeAttribute(typeof(LinkPreviewBlock), BlockType.LinkPreviewValue)]
     [JsonSubtypes.KnownSubTypeAttribute(typeof(LinkToPageBlock), BlockType.LinkToPageValue)]

--- a/Src/Notion.Client/Models/Blocks/Request/HeadingFourBlockRequest.cs
+++ b/Src/Notion.Client/Models/Blocks/Request/HeadingFourBlockRequest.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public class HeadingFourBlockRequest : BlockObjectRequest, IColumnChildrenBlockRequest, INonColumnBlockRequest
+    {
+        [JsonProperty("heading_4")]
+        [SuppressMessage("ReSharper", "InconsistentNaming")]
+        public Info Heading_4 { get; set; }
+
+        public override BlockType Type => BlockType.Heading4;
+
+        public class Info
+        {
+            [JsonProperty("rich_text")]
+            public IEnumerable<RichTextBase> RichText { get; set; }
+
+            [JsonProperty("color")]
+            public Color? Color { get; set; }
+
+            [JsonProperty("is_toggleable")]
+            public bool IsToggleable { get; set; }
+        }
+    }
+}

--- a/Test/Notion.IntegrationTests/BlocksClientTests.cs
+++ b/Test/Notion.IntegrationTests/BlocksClientTests.cs
@@ -613,6 +613,35 @@ public class IBlocksClientTests : IntegrationTestBase, IAsyncLifetime
                         .Subject.Should().BeOfType<RichTextText>().Subject
                         .Text.Content.Should().Be("Test file caption");
                 })
+            },
+            new object[]
+            {
+                new HeadingFourBlockRequest
+                {
+                    Heading_4 = new HeadingFourBlockRequest.Info
+                    {
+                        RichText = new List<RichTextBaseInput>
+                        {
+                            new RichTextTextInput { Text = new Text { Content = "Heading 4 original" } }
+                        }
+                    }
+                },
+                new HeadingFourUpdateBlock
+                {
+                    Heading_4 = new HeadingFourUpdateBlock.Info
+                    {
+                        RichText = new List<RichTextBaseInput>
+                        {
+                            new RichTextTextInput { Text = new Text { Content = "Heading 4 updated" } }
+                        }
+                    }
+                },
+                new Action<IBlock, INotionClient>((block, _) =>
+                {
+                    var heading4 = block.Should().NotBeNull().And.BeOfType<HeadingFourBlock>().Subject;
+                    heading4.Heading_4.RichText.OfType<RichTextText>().First().Text.Content
+                        .Should().Be("Heading 4 updated");
+                })
             }
         };
     }


### PR DESCRIPTION
## Summary

- Adds `BlockType.Heading4` (`"heading_4"`)
- Adds `HeadingFourBlock` (read model) — same shape as `HeadingOneBlock`/`HeadingTwoBlock`/`HeadingThreeBlock`
- Adds `HeadingFourBlockRequest` (create model) — for use with Append block children
- Adds `HeadingFourUpdateBlock` (update model) — for use with Update a block
- Registers `HeadingFourBlock` in `IBlock` polymorphic discriminator

Closes #537

## Test plan
- [ ] Build passes with no warnings
- [ ] Unit tests pass
- [ ] Manually verify retrieving a page with heading_4 blocks deserializes as `HeadingFourBlock`
- [ ] Manually verify creating a `HeadingFourBlockRequest` via AppendBlockChildren works
- [ ] Manually verify updating with `HeadingFourUpdateBlock` works