### PR TITLE
feat: add retrieve single, update, and delete comment endpoints (#590)

### DIFF
--- a/Src/Notion.Client/Api/ApiEndpoints.cs
+++ b/Src/Notion.Client/Api/ApiEndpoints.cs
@@ -124,6 +124,12 @@
             {
                 return "/v1/comments";
             }
+
+            public static string RetrieveSingle(string commentId) => $"/v1/comments/{commentId}";
+
+            public static string Update(string commentId) => $"/v1/comments/{commentId}";
+
+            public static string Delete(string commentId) => $"/v1/comments/{commentId}";
         }
 
         public static class AuthenticationUrls

--- a/Src/Notion.Client/Api/Comments/Delete/CommentsClient.cs
+++ b/Src/Notion.Client/Api/Comments/Delete/CommentsClient.cs
@@ -1,0 +1,18 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Notion.Client
+{
+    public partial class CommentsClient
+    {
+        public async Task DeleteAsync(
+            string commentId,
+            CancellationToken cancellationToken = default)
+        {
+            await _client.DeleteAsync(
+                ApiEndpoints.CommentsApiUrls.Delete(commentId),
+                cancellationToken: cancellationToken
+            );
+        }
+    }
+}

--- a/Src/Notion.Client/Api/Comments/ICommentsClient.cs
+++ b/Src/Notion.Client/Api/Comments/ICommentsClient.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Notion.Client
@@ -8,5 +8,20 @@ namespace Notion.Client
         Task<Comment> CreateAsync(CreateCommentRequest createCommentParameters, CancellationToken cancellationToken = default);
 
         Task<RetrieveCommentsResponse> RetrieveAsync(RetrieveCommentsRequest parameters, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieve a single comment by its ID.
+        /// </summary>
+        Task<Comment> RetrieveSingleAsync(RetrieveSingleCommentRequest request, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Update a comment's rich_text content.
+        /// </summary>
+        Task<Comment> UpdateAsync(UpdateCommentRequest request, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete a comment by its ID.
+        /// </summary>
+        Task DeleteAsync(string commentId, CancellationToken cancellationToken = default);
     }
 }

--- a/Src/Notion.Client/Api/Comments/RetrieveSingle/CommentsClient.cs
+++ b/Src/Notion.Client/Api/Comments/RetrieveSingle/CommentsClient.cs
@@ -1,0 +1,18 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Notion.Client
+{
+    public partial class CommentsClient
+    {
+        public async Task<Comment> RetrieveSingleAsync(
+            RetrieveSingleCommentRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            return await _client.GetAsync<Comment>(
+                ApiEndpoints.CommentsApiUrls.RetrieveSingle(request.CommentId),
+                cancellationToken: cancellationToken
+            );
+        }
+    }
+}

--- a/Src/Notion.Client/Api/Comments/RetrieveSingle/Request/RetrieveSingleCommentRequest.cs
+++ b/Src/Notion.Client/Api/Comments/RetrieveSingle/Request/RetrieveSingleCommentRequest.cs
@@ -1,0 +1,7 @@
+namespace Notion.Client
+{
+    public class RetrieveSingleCommentRequest
+    {
+        public string CommentId { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Comments/Update/CommentsClient.cs
+++ b/Src/Notion.Client/Api/Comments/Update/CommentsClient.cs
@@ -1,0 +1,19 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Notion.Client
+{
+    public partial class CommentsClient
+    {
+        public async Task<Comment> UpdateAsync(
+            UpdateCommentRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            return await _client.PatchAsync<Comment>(
+                ApiEndpoints.CommentsApiUrls.Update(request.CommentId),
+                request,
+                cancellationToken: cancellationToken
+            );
+        }
+    }
+}

--- a/Src/Notion.Client/Api/Comments/Update/Request/UpdateCommentRequest.cs
+++ b/Src/Notion.Client/Api/Comments/Update/Request/UpdateCommentRequest.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public class UpdateCommentRequest
+    {
+        public string CommentId { get; set; }
+
+        [JsonProperty("rich_text")]
+        public IEnumerable<RichTextBase> RichText { get; set; }
+    }
+}

--- a/Test/Notion.IntegrationTests/CommentsClientTests.cs
+++ b/Test/Notion.IntegrationTests/CommentsClientTests.cs
@@ -89,4 +89,78 @@ public class CommentsClientTests : IntegrationTestBase, IAsyncLifetime
         var pageParent = Assert.IsType<PageParent>(response.Parent);
         Assert.Equal(_page.Id, pageParent.PageId);
     }
+
+    [Fact]
+    public async Task ShouldRetrieveSingleComment()
+    {
+        // Arrange — create a comment first
+        var created = await Client.Comments.CreateAsync(
+            CreateCommentRequest.CreatePageComment(
+                new ParentPageInput { PageId = _page.Id },
+                new List<RichTextBaseInput> { new RichTextTextInput { Text = new Text { Content = "Comment to retrieve" } } }
+            )
+        );
+
+        // Act
+        var retrieved = await Client.Comments.RetrieveSingleAsync(
+            new RetrieveSingleCommentRequest { CommentId = created.Id }
+        );
+
+        // Assert
+        Assert.NotNull(retrieved);
+        Assert.Equal(created.Id, retrieved.Id);
+        Assert.Equal(created.DiscussionId, retrieved.DiscussionId);
+        var richText = Assert.IsType<RichTextText>(retrieved.RichText.First());
+        Assert.Equal("Comment to retrieve", richText.Text.Content);
+    }
+
+    [Fact]
+    public async Task ShouldUpdateComment()
+    {
+        // Arrange — create a comment first
+        var created = await Client.Comments.CreateAsync(
+            CreateCommentRequest.CreatePageComment(
+                new ParentPageInput { PageId = _page.Id },
+                new List<RichTextBaseInput> { new RichTextTextInput { Text = new Text { Content = "Original text" } } }
+            )
+        );
+
+        // Act
+        var updated = await Client.Comments.UpdateAsync(new UpdateCommentRequest
+        {
+            CommentId = created.Id,
+            RichText = new List<RichTextBase>
+            {
+                new RichTextText { Text = new Text { Content = "Updated text" } }
+            }
+        });
+
+        // Assert
+        Assert.NotNull(updated);
+        Assert.Equal(created.Id, updated.Id);
+        var richText = Assert.IsType<RichTextText>(updated.RichText.First());
+        Assert.Equal("Updated text", richText.Text.Content);
+    }
+
+    [Fact]
+    public async Task ShouldDeleteComment()
+    {
+        // Arrange — create a comment first
+        var created = await Client.Comments.CreateAsync(
+            CreateCommentRequest.CreatePageComment(
+                new ParentPageInput { PageId = _page.Id },
+                new List<RichTextBaseInput> { new RichTextTextInput { Text = new Text { Content = "Comment to delete" } } }
+            )
+        );
+
+        // Act — delete should not throw
+        await Client.Comments.DeleteAsync(created.Id);
+
+        // Assert — retrieving the deleted comment should fail or return nothing
+        var comments = await Client.Comments.RetrieveAsync(
+            new RetrieveCommentsRequest { BlockId = _page.Id }
+        );
+
+        Assert.DoesNotContain(comments.Results, c => c.Id == created.Id);
+    }
 }


### PR DESCRIPTION
## Summary

Adds three missing comment operations to `ICommentsClient`:

- `RetrieveSingleAsync(RetrieveSingleCommentRequest)` — `GET /v1/comments/:comment_id`
- `UpdateAsync(UpdateCommentRequest)` — `PATCH /v1/comments/:comment_id` with `rich_text` body
- `DeleteAsync(string commentId)` — `DELETE /v1/comments/:comment_id`

Closes #590

## Test plan
- [ ] Build passes with no warnings
- [ ] Unit tests pass
- [ ] Manually verify `RetrieveSingleAsync` returns the correct comment
- [ ] Manually verify `UpdateAsync` updates the comment rich text
- [ ] Manually verify `DeleteAsync` removes the comment