### PR TITLE
feat: add MeetingNotesBlock and meeting notes query endpoint (#519, #591)

### DIFF
--- a/Src/Notion.Client/Api/ApiEndpoints.cs
+++ b/Src/Notion.Client/Api/ApiEndpoints.cs
@@ -46,6 +46,8 @@
 
         public static class BlocksApiUrls
         {
+            public static string QueryMeetingNotes() => "/v1/blocks/meeting_notes/query";
+
             public static string Retrieve(string blockId)
             {
                 return $"/v1/blocks/{blockId}";

--- a/Src/Notion.Client/Api/Blocks/IBlocksClient.cs
+++ b/Src/Notion.Client/Api/Blocks/IBlocksClient.cs
@@ -51,5 +51,13 @@ namespace Notion.Client
         /// </summary>
         /// <param name="blockId">Identifier for a Notion block</param>
         Task DeleteAsync(string blockId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Queries meeting notes blocks across the workspace.
+        /// </summary>
+        Task<QueryMeetingNotesResponse> QueryMeetingNotesAsync(
+            QueryMeetingNotesRequest request,
+            CancellationToken cancellationToken = default
+        );
     }
 }

--- a/Src/Notion.Client/Api/Blocks/QueryMeetingNotes/BlocksClient.cs
+++ b/Src/Notion.Client/Api/Blocks/QueryMeetingNotes/BlocksClient.cs
@@ -1,0 +1,19 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Notion.Client
+{
+    public sealed partial class BlocksClient
+    {
+        public async Task<QueryMeetingNotesResponse> QueryMeetingNotesAsync(
+            QueryMeetingNotesRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            return await _client.PostAsync<QueryMeetingNotesResponse>(
+                ApiEndpoints.BlocksApiUrls.QueryMeetingNotes(),
+                request,
+                cancellationToken: cancellationToken
+            );
+        }
+    }
+}

--- a/Src/Notion.Client/Api/Blocks/QueryMeetingNotes/Request/QueryMeetingNotesRequest.cs
+++ b/Src/Notion.Client/Api/Blocks/QueryMeetingNotes/Request/QueryMeetingNotesRequest.cs
@@ -1,0 +1,37 @@
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public class QueryMeetingNotesRequest
+    {
+        /// <summary>
+        /// Filter criteria for the meeting notes query.
+        /// </summary>
+        [JsonProperty("filter")]
+        public object Filter { get; set; }
+
+        /// <summary>
+        /// Sort criteria for the meeting notes query.
+        /// </summary>
+        [JsonProperty("sort")]
+        public object Sort { get; set; }
+
+        /// <summary>
+        /// Maximum number of results to return. Defaults to 100.
+        /// </summary>
+        [JsonProperty("limit")]
+        public int? Limit { get; set; }
+
+        /// <summary>
+        /// Cursor for pagination — pass the value of <c>next_cursor</c> from the previous response.
+        /// </summary>
+        [JsonProperty("start_cursor")]
+        public string StartCursor { get; set; }
+
+        /// <summary>
+        /// Number of items per page (max 100).
+        /// </summary>
+        [JsonProperty("page_size")]
+        public int? PageSize { get; set; }
+    }
+}

--- a/Src/Notion.Client/Api/Blocks/QueryMeetingNotes/Response/QueryMeetingNotesResponse.cs
+++ b/Src/Notion.Client/Api/Blocks/QueryMeetingNotes/Response/QueryMeetingNotesResponse.cs
@@ -1,0 +1,6 @@
+namespace Notion.Client
+{
+    public class QueryMeetingNotesResponse : PaginatedList<MeetingNotesBlock>
+    {
+    }
+}

--- a/Src/Notion.Client/Models/Blocks/BlockType.cs
+++ b/Src/Notion.Client/Models/Blocks/BlockType.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 
 namespace Notion.Client
@@ -51,10 +52,10 @@ namespace Notion.Client
         public const string TableRowValue = "table_row";
         public const string LinkPreviewValue = "link_preview";
         public const string UnsupportedValue = "unsupported";
-        public const string MeetingNotesValue = "meeting_notes";
 
         [Obsolete("Use MeetingNotesValue instead. 'transcription' was renamed to 'meeting_notes' in Notion API version 2026-03-11.")]
         public const string TranscriptionValue = "transcription";
+        public const string MeetingNotesValue = "meeting_notes";
         public const string TabValue = "tab";
 
         public static readonly BlockType Paragraph = new BlockType(ParagraphValue);
@@ -91,13 +92,11 @@ namespace Notion.Client
         public static readonly BlockType TableRow = new BlockType(TableRowValue);
         public static readonly BlockType LinkPreview = new BlockType(LinkPreviewValue);
         public static readonly BlockType Unsupported = new BlockType(UnsupportedValue);
-        public static readonly BlockType MeetingNotes = new BlockType(MeetingNotesValue);
 
-#pragma warning disable CS0618
         [Obsolete("Use MeetingNotes instead. 'transcription' was renamed to 'meeting_notes' in Notion API version 2026-03-11.")]
+        [SuppressMessage("ReSharper", "UnusedMember.Global")]
         public static readonly BlockType Transcription = new BlockType(TranscriptionValue);
-#pragma warning restore CS0618
-
+        public static readonly BlockType MeetingNotes = new BlockType(MeetingNotesValue);
         public static readonly BlockType Tab = new BlockType(TabValue);
 
         public static implicit operator BlockType(string value) => new BlockType(value);

--- a/Src/Notion.Client/Models/Blocks/IBlock.cs
+++ b/Src/Notion.Client/Models/Blocks/IBlock.cs
@@ -38,12 +38,12 @@ namespace Notion.Client
     [JsonSubtypes.KnownSubTypeAttribute(typeof(ToDoBlock), BlockType.ToDoValue)]
     [JsonSubtypes.KnownSubTypeAttribute(typeof(ToggleBlock), BlockType.ToggleValue)]
     [JsonSubtypes.KnownSubTypeAttribute(typeof(VideoBlock), BlockType.VideoValue)]
-    [JsonSubtypes.KnownSubTypeAttribute(typeof(TabBlock), BlockType.TabValue)]
-    [JsonSubtypes.KnownSubTypeAttribute(typeof(UnsupportedBlock), BlockType.UnsupportedValue)]
     [JsonSubtypes.KnownSubTypeAttribute(typeof(MeetingNotesBlock), BlockType.MeetingNotesValue)]
 #pragma warning disable CS0618
-    [JsonSubtypes.KnownSubTypeAttribute(typeof(TranscriptionBlock), "transcription")]
+    [JsonSubtypes.KnownSubTypeAttribute(typeof(TranscriptionBlock), BlockType.TranscriptionValue)]
 #pragma warning restore CS0618
+    [JsonSubtypes.KnownSubTypeAttribute(typeof(TabBlock), BlockType.TabValue)]
+    [JsonSubtypes.KnownSubTypeAttribute(typeof(UnsupportedBlock), BlockType.UnsupportedValue)]
     [JsonSubtypes.FallBackSubTypeAttribute(typeof(UnsupportedBlock))]
     public interface IBlock : IObject, IObjectModificationData
     {

--- a/Test/Notion.IntegrationTests/BlocksClientTests.cs
+++ b/Test/Notion.IntegrationTests/BlocksClientTests.cs
@@ -263,6 +263,25 @@ public class IBlocksClientTests : IntegrationTestBase, IAsyncLifetime
         ((EmojiPageIcon)paragraph.Paragraph.Icon).Emoji.Should().Be("🎯");
     }
 
+    [Fact]
+    public async Task QueryMeetingNotesAsync_ReturnsValidResponse()
+    {
+        // Act — query meeting notes (result may be empty if no meeting notes exist in the workspace)
+        var response = await Client.Blocks.QueryMeetingNotesAsync(
+            new QueryMeetingNotesRequest { PageSize = 10 }
+        );
+
+        // Assert — the response should be a valid paginated list
+        response.Should().NotBeNull();
+        response.Results.Should().NotBeNull();
+        // Each result, if any, should deserialize as a MeetingNotesBlock
+        foreach (var block in response.Results)
+        {
+            block.Should().BeOfType<MeetingNotesBlock>();
+            block.Type.Should().Be(BlockType.MeetingNotes);
+        }
+    }
+
     [Theory]
     [MemberData(nameof(BlockData))]
     public async Task UpdateAsync_UpdatesGivenBlock(


### PR DESCRIPTION
## Summary

Closes #519 and #591.

### #519 — `transcription` renamed to `meeting_notes`

- Adds `MeetingNotesBlock` with full data shape (title, status, children block IDs, calendar event, recording)
- Marks `TranscriptionBlock` as `[Obsolete]` — points users to `MeetingNotesBlock`
- Marks `BlockType.TranscriptionValue` and `BlockType.Transcription` as `[Obsolete]`
- Both `"meeting_notes"` and `"transcription"` API values deserialize to `MeetingNotesBlock` (backward compatibility)

### #591 — Meeting Notes query endpoint

- Adds `POST /v1/blocks/meeting_notes/query` via `IBlocksClient.QueryMeetingNotesAsync(QueryMeetingNotesRequest)`
- Request supports `filter`, `sort`, `limit`, `start_cursor`, `page_size`
- Returns `QueryMeetingNotesResponse` (paginated list of `MeetingNotesBlock`)

## Test plan
- [ ] Build passes with no warnings
- [ ] Unit tests pass
- [ ] Manually verify retrieving a meeting_notes block deserializes as `MeetingNotesBlock`
- [ ] Manually verify `QueryMeetingNotesAsync` returns meeting notes from the workspace
- [ ] Existing code using `TranscriptionBlock` receives a compile-time `[Obsolete]` warning