### PR TITLE
feat: add Place property type support (#592)

### DIFF
--- a/Src/Notion.Client/Models/PropertyItems/PlacePropertyItem.cs
+++ b/Src/Notion.Client/Models/PropertyItems/PlacePropertyItem.cs
@@ -1,0 +1,12 @@
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    public class PlacePropertyItem : SimplePropertyItem
+    {
+        public override string Type => "place";
+
+        [JsonProperty("place")]
+        public PlacePropertyValue.PlaceInfo Place { get; set; }
+    }
+}

--- a/Src/Notion.Client/Models/PropertyItems/SimplePropertyItem.cs
+++ b/Src/Notion.Client/Models/PropertyItems/SimplePropertyItem.cs
@@ -25,6 +25,7 @@ namespace Notion.Client
     [JsonSubtypes.KnownSubTypeAttribute(typeof(PeoplePropertyItem), "people")]
     [JsonSubtypes.KnownSubTypeAttribute(typeof(RelationPropertyItem), "relation")]
     [JsonSubtypes.KnownSubTypeAttribute(typeof(RollupPropertyItem), "rollup")]
+    [JsonSubtypes.KnownSubTypeAttribute(typeof(PlacePropertyItem), "place")]
     [JsonSubtypes.FallBackSubTypeAttribute(typeof(SimplePropertyItem))]
     [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
     public abstract class SimplePropertyItem : IPropertyItemObject

--- a/Src/Notion.Client/Models/PropertyValue/PlacePropertyValue.cs
+++ b/Src/Notion.Client/Models/PropertyValue/PlacePropertyValue.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Notion.Client
 {

--- a/Test/Notion.IntegrationTests/PageClientTests.cs
+++ b/Test/Notion.IntegrationTests/PageClientTests.cs
@@ -512,4 +512,55 @@ public class PageClientTests : IntegrationTestBase, IAsyncLifetime
         Assert.NotNull(markdownResponse.Markdown);
         Assert.Contains("This is a test page.", markdownResponse.Markdown);
     }
+
+    [Fact]
+    public async Task RetrievePagePropertyItemAsync_PlaceProperty_DeserializesAsPlacePropertyItem()
+    {
+        // Arrange — create a database with a Place property
+        const string PlacePropertyName = "Location";
+
+        var databaseCreateRequest = new DatabasesCreateRequest
+        {
+            Title = new List<RichTextBaseInput>
+            {
+                new RichTextTextInput { Text = new Text { Content = "Place Property Test DB" } }
+            },
+            Parent = new PageParentOfDatabaseRequest { PageId = _page.Id },
+            InitialDataSource = new InitialDataSourceRequest
+            {
+                Properties = new Dictionary<string, DataSourcePropertyConfigRequest>
+                {
+                    { "Name", new TitleDataSourcePropertyConfigRequest { Title = new Dictionary<string, object>() } },
+                    { PlacePropertyName, new PlaceDataSourcePropertyConfigRequest { Place = new Dictionary<string, object>() } }
+                }
+            }
+        };
+
+        var database = await Client.Databases.CreateAsync(databaseCreateRequest);
+
+        var page = await Client.Pages.CreateAsync(
+            PagesCreateParametersBuilder
+                .Create(new DataSourceParentRequest { DataSourceId = database.DataSources.First().DataSourceId })
+                .AddProperty("Name", new TitlePropertyValue
+                {
+                    Title = new List<RichTextBase>
+                    {
+                        new RichTextText { Text = new Text { Content = "Place test page" } }
+                    }
+                })
+                .Build()
+        );
+
+        // Act — retrieve the place property item
+        var propertyId = page.Properties[PlacePropertyName].Id;
+        var propertyItem = await Client.Pages.RetrievePagePropertyItemAsync(new RetrievePropertyItemParameters
+        {
+            PageId = page.Id,
+            PropertyId = propertyId
+        });
+
+        // Assert — the property item should be a PlacePropertyItem
+        propertyItem.Should().NotBeNull();
+        propertyItem.Should().BeOfType<PlacePropertyItem>();
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `PlacePropertyItem` (registered in `SimplePropertyItem` discriminator under `"place"`)
- Reuses the existing `PlacePropertyValue.PlaceInfo` model for the property item data shape — avoids duplication
- `PlacePropertyValue` and `PlaceProperty` were already present and registered; this PR completes the trilogy

Closes #592

## Test plan
- [ ] Build passes with no warnings
- [ ] Unit tests pass
- [ ] Manually verify that retrieving a page property item for a place property deserializes as `PlacePropertyItem`