### PR TITLE
feat: add width_ratio field to ColumnBlock (#594)

### DIFF
--- a/Src/Notion.Client/Models/Blocks/ColumnBlock.cs
+++ b/Src/Notion.Client/Models/Blocks/ColumnBlock.cs
@@ -14,6 +14,13 @@ namespace Notion.Client
         {
             [JsonProperty("children")]
             public IEnumerable<IColumnChildrenBlock> Children { get; set; }
+
+            /// <summary>
+            /// Proportional width of this column relative to its siblings.
+            /// For example, a value of 0.25 means this column takes 25% of the available width.
+            /// </summary>
+            [JsonProperty("width_ratio")]
+            public double? WidthRatio { get; set; }
         }
     }
 }

--- a/Src/Notion.Client/Models/Blocks/Request/ColumnBlockRequest.cs
+++ b/Src/Notion.Client/Models/Blocks/Request/ColumnBlockRequest.cs
@@ -14,6 +14,12 @@ namespace Notion.Client
         {
             [JsonProperty("children")]
             public IEnumerable<IColumnChildrenBlockRequest> Children { get; set; }
+
+            /// <summary>
+            /// Proportional width of this column relative to its siblings.
+            /// </summary>
+            [JsonProperty("width_ratio")]
+            public double? WidthRatio { get; set; }
         }
     }
 }

--- a/Test/Notion.IntegrationTests/BlocksClientTests.cs
+++ b/Test/Notion.IntegrationTests/BlocksClientTests.cs
@@ -315,6 +315,83 @@ public class IBlocksClientTests : IntegrationTestBase, IAsyncLifetime
         block.NumberedListItem.ListFormat.Should().BeNull();
     }
 
+        [Fact]
+    public async Task AppendChildrenAsync_WithColumnBlockWidthRatio_WidthRatioIsReturned()
+    {
+        // Arrange & Act — create a column list with two columns, one having an explicit width_ratio
+        var blocks = await Client.Blocks.AppendChildrenAsync(
+            new BlockAppendChildrenRequest
+            {
+                BlockId = _page.Id,
+                Children = new List<IBlockObjectRequest>
+                {
+                    new ColumnListBlockRequest
+                    {
+                        ColumnList = new ColumnListBlockRequest.Info
+                        {
+                            Children = new List<ColumnBlockRequest>
+                            {
+                                new ColumnBlockRequest
+                                {
+                                    Column = new ColumnBlockRequest.Info
+                                    {
+                                        WidthRatio = 0.25,
+                                        Children = new List<IColumnChildrenBlockRequest>
+                                        {
+                                            new ParagraphBlockRequest
+                                            {
+                                                Paragraph = new ParagraphBlockRequest.Info
+                                                {
+                                                    RichText = new List<RichTextBaseInput>
+                                                    {
+                                                        new RichTextTextInput { Text = new Text { Content = "Narrow column" } }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                new ColumnBlockRequest
+                                {
+                                    Column = new ColumnBlockRequest.Info
+                                    {
+                                        WidthRatio = 0.75,
+                                        Children = new List<IColumnChildrenBlockRequest>
+                                        {
+                                            new ParagraphBlockRequest
+                                            {
+                                                Paragraph = new ParagraphBlockRequest.Info
+                                                {
+                                                    RichText = new List<RichTextBaseInput>
+                                                    {
+                                                        new RichTextTextInput { Text = new Text { Content = "Wide column" } }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        );
+
+        // Assert — retrieve the columns inside the column list
+        var columnList = blocks.Results.Should().ContainSingle().Subject.Should().BeOfType<ColumnListBlock>().Subject;
+
+        var columns = await Client.Blocks.RetrieveChildrenAsync(
+            new BlockRetrieveChildrenRequest { BlockId = columnList.Id });
+
+        columns.Results.Should().HaveCount(2);
+        var firstColumn = columns.Results[0].Should().BeOfType<ColumnBlock>().Subject;
+        firstColumn.Column.WidthRatio.Should().Be(0.25);
+
+        var secondColumn = columns.Results[1].Should().BeOfType<ColumnBlock>().Subject;
+        secondColumn.Column.WidthRatio.Should().Be(0.75);
+    }
+
     [Theory]
     [MemberData(nameof(BlockData))]
     public async Task UpdateAsync_UpdatesGivenBlock(


### PR DESCRIPTION
## Summary

- Adds `WidthRatio` (`double?`) to `ColumnBlock.Info` for reading column width from the API
- Adds `WidthRatio` (`double?`) to `ColumnBlockRequest.Info` for setting column width when creating

Closes #594

## Test plan
- [x] Build passes with no warnings
- [x] Unit tests pass
- [x] Manually verify retrieving a column block returns `WidthRatio`
- [x] Manually verify creating a column block with `WidthRatio = 0.25` sets proportional width