### PR TITLE
feat: add IsLocked to Page model, closes remaining 5.1.0 field issues (#595 #596 #597)

### DIFF
--- a/Src/Notion.Client/Models/Page/Page.cs
+++ b/Src/Notion.Client/Models/Page/Page.cs
@@ -19,6 +19,12 @@ namespace Notion.Client
         public bool InTrash { get; set; }
 
         /// <summary>
+        ///     Whether the page is locked from editing in the Notion app UI.
+        /// </summary>
+        [JsonProperty("is_locked")]
+        public bool? IsLocked { get; set; }
+
+        /// <summary>
         ///     Property values of this page.
         /// </summary>
         [JsonProperty("properties")]

--- a/Test/Notion.IntegrationTests/PageClientTests.cs
+++ b/Test/Notion.IntegrationTests/PageClientTests.cs
@@ -563,4 +563,16 @@ public class PageClientTests : IntegrationTestBase, IAsyncLifetime
         propertyItem.Should().NotBeNull();
         propertyItem.Should().BeOfType<PlacePropertyItem>();
     }
+
+    [Fact]
+    public async Task RetrieveAsync_PageHasIsLockedField()
+    {
+        // Act — retrieve the page that was created in InitializeAsync
+        var page = await Client.Pages.RetrieveAsync(_page.Id);
+
+        // Assert — is_locked should be present (false by default for newly created pages)
+        page.Should().NotBeNull();
+        // The field is nullable — a new page is not locked, so it should be false or null
+        page.IsLocked.Should().NotBeTrue();
+    }
 }


### PR DESCRIPTION
## Summary

This PR resolves the last three 5.1.0 milestone field issues:

### #595 — `erase_content` in PagesUpdateParameters
Already implemented — `EraseContent` (`bool?`) is present in `PagesUpdateParameters` and `IPagesUpdateBodyParameters`.

### #596 — `is_locked` on Page and Database
- `IsLocked` was already present on `Database`, `PagesUpdateParameters`, and `DatabasesUpdateRequest`
- This PR adds the missing `IsLocked` (`bool?`) to the `Page` response model

### #597 — `template` in PagesCreateParameters
Already implemented — `PageTemplate` (abstract with `NonePageTemplate`, `DefaultPageTemplate`, `TemplateIdPageTemplate` subtypes) is present in `PagesCreateParameters` and `IPagesCreateBodyParameters`.

Closes #595, #596, #597

## Test plan
- [ ] Build passes with no warnings
- [ ] Unit tests pass
- [ ] Manually verify `Page.IsLocked` is populated when retrieving a locked page