### PR TITLE
chore: bump default Notion-Version to 2026-03-11

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ dotnet add package Notion.Net
 **Note:** Default Notion-Version used by NuGet package versions
 | Package version | Notion-Version |
 | --- | --- |
-| 5.0.0-preview+ | 2025-09-03 |
+| 6.0.0+ | 2026-03-11 |
+| 5.0.0+ | 2025-09-03 |
 | 4.4.0+ | 2022-06-28 |
-| 4.3.0+ | 2022-06-28 | 
-| 4.0.0+ | 2022-06-28 | 
+| 4.0.0+ | 2022-06-28 |
 | 3.0.0+ | 2022-02-22 |
 | 2.0.0+ | 2021-08-16 |
 | 1.0.0+ | 2021-05-13 |

--- a/Src/Notion.Client/Constants.cs
+++ b/Src/Notion.Client/Constants.cs
@@ -7,7 +7,7 @@ namespace Notion.Client
     internal static class Constants
     {
         internal const string BaseUrl = "https://api.notion.com/";
-        internal const string DefaultNotionVersion = "2025-09-03";
+        internal const string DefaultNotionVersion = "2026-03-11";
         internal const string HttpClientName = "NotionClient";
     }
 }


### PR DESCRIPTION
## Summary

Bumps `Constants.DefaultNotionVersion` from `2025-09-03` to `2026-03-11`.

This is required for the 6.0.0 release — all features in this milestone target the `2026-03-11` API version:

- `in_trash` replaces `archived` on pages, databases, blocks, file uploads, data sources (#518)
- `meeting_notes` replaces `transcription` block type (#519)
- Tab block type (#534)
- Heading 4 block type (#537)
- `position` object on Append block children (#517)
- Comment retrieve/update/delete (#590)
- Meeting notes query endpoint (#591)
- And many more model additions

Also updates the version table in `README.md` to add the `6.0.0 → 2026-03-11` row.

Users who need to stay on `2025-09-03` can still pin it explicitly:
```csharp
NotionClientFactory.Create(new ClientOptions
{
    AuthToken = "<Token>",
    NotionVersion = "2025-09-03"  // explicit override
});
```

## Breaking change
Existing integrations using the default version will now send `Notion-Version: 2026-03-11` to the Notion API, which may change response shapes (e.g. `archived` → `in_trash`). This is intentional for 6.0.0.