### PR TITLE
feat: add webhook support and pagination/ID helpers

### DIFF
--- a/Src/Notion.Client/Extensions/NotionIdHelper.cs
+++ b/Src/Notion.Client/Extensions/NotionIdHelper.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace Notion.Client
+{
+    /// <summary>
+    /// Helper utilities for extracting and normalising Notion UUIDs from URLs or raw ID strings.
+    /// </summary>
+    public static class NotionIdHelper
+    {
+        // Matches a fully-hyphenated UUID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+        private static readonly Regex HyphenatedUuidRegex = new Regex(
+            @"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        // Matches exactly 32 consecutive hex characters (compact UUID, no hyphens)
+        private static readonly Regex CompactUuidRegex = new Regex(
+            @"^[0-9a-f]{32}$",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        // Extracts the last 32-hex-char segment from a URL path segment.
+        // Mirrors the JS SDK pattern: /-([0-9a-f]{32})(?:[/?#]|$)/
+        private static readonly Regex PathSegmentRegex = new Regex(
+            @"-([0-9a-f]{32})(?:[/?#]|$)",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        // Fallback: any 32 consecutive hex chars anywhere in the string
+        private static readonly Regex AnyCompactUuidRegex = new Regex(
+            @"[0-9a-f]{32}",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        // Block fragment: #block-<32hex> or #<32hex>
+        private static readonly Regex BlockFragmentRegex = new Regex(
+            @"#(?:block-)?([0-9a-f]{32})(?:[/?#]|$)",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        /// <summary>
+        /// Formats a raw 32-character hex string into the standard
+        /// <c>xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx</c> UUID form.
+        /// </summary>
+        private static string FormatUuid(string compact)
+        {
+            var s = compact.ToLowerInvariant();
+            return $"{s.Substring(0, 8)}-{s.Substring(8, 4)}-{s.Substring(12, 4)}-{s.Substring(16, 4)}-{s.Substring(20, 12)}";
+        }
+
+        /// <summary>
+        /// Extracts a Notion UUID from a URL or passes it through if it is already a UUID.
+        /// </summary>
+        /// <param name="urlOrId">A Notion page/database URL, a hyphenated UUID, or a compact UUID.</param>
+        /// <returns>
+        /// A lower-cased, hyphenated UUID string; or <see langword="null"/> if no valid ID
+        /// could be found.
+        /// </returns>
+        public static string ExtractNotionId(string urlOrId)
+        {
+            if (string.IsNullOrWhiteSpace(urlOrId))
+            {
+                return null;
+            }
+
+            var trimmed = urlOrId.Trim();
+
+            // 1. Already a hyphenated UUID — return as-is (lowercased)
+            if (HyphenatedUuidRegex.IsMatch(trimmed))
+            {
+                return trimmed.ToLowerInvariant();
+            }
+
+            // 2. Compact (32 hex chars) UUID — format and return
+            if (CompactUuidRegex.IsMatch(trimmed))
+            {
+                return FormatUuid(trimmed);
+            }
+
+            // From here on we treat the input as a URL.
+
+            // 3. Extract from URL path: pattern /-([0-9a-f]{32})(?:[/?#]|$)/
+            var pathMatch = PathSegmentRegex.Match(trimmed);
+            if (pathMatch.Success)
+            {
+                return FormatUuid(pathMatch.Groups[1].Value);
+            }
+
+            // 4. Fallback to known query parameters
+            foreach (var paramName in new[] { "p", "page_id", "database_id" })
+            {
+                var paramValue = GetQueryParam(trimmed, paramName);
+                if (paramValue != null)
+                {
+                    // The query param value may itself be a compact or hyphenated UUID
+                    var extracted = ExtractNotionId(paramValue);
+                    if (extracted != null)
+                    {
+                        return extracted;
+                    }
+                }
+            }
+
+            // 5. Last resort: any 32 hex chars in the URL
+            var anyMatch = AnyCompactUuidRegex.Match(trimmed);
+            if (anyMatch.Success)
+            {
+                return FormatUuid(anyMatch.Value);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Convenience wrapper around <see cref="ExtractNotionId"/> for page URLs.
+        /// </summary>
+        /// <param name="pageUrl">A Notion page URL or ID.</param>
+        /// <returns>A hyphenated UUID; or <see langword="null"/> if not found.</returns>
+        public static string ExtractPageId(string pageUrl)
+        {
+            return ExtractNotionId(pageUrl);
+        }
+
+        /// <summary>
+        /// Convenience wrapper around <see cref="ExtractNotionId"/> for database URLs.
+        /// </summary>
+        /// <param name="dbUrl">A Notion database URL or ID.</param>
+        /// <returns>A hyphenated UUID; or <see langword="null"/> if not found.</returns>
+        public static string ExtractDatabaseId(string dbUrl)
+        {
+            return ExtractNotionId(dbUrl);
+        }
+
+        /// <summary>
+        /// Extracts a block ID from a URL fragment of the form
+        /// <c>#block-&lt;32hex&gt;</c> or <c>#&lt;32hex&gt;</c>.
+        /// </summary>
+        /// <param name="urlWithBlock">A Notion URL that contains a block fragment.</param>
+        /// <returns>A hyphenated UUID for the block; or <see langword="null"/> if not found.</returns>
+        public static string ExtractBlockId(string urlWithBlock)
+        {
+            if (string.IsNullOrWhiteSpace(urlWithBlock))
+            {
+                return null;
+            }
+
+            var match = BlockFragmentRegex.Match(urlWithBlock.Trim());
+            if (match.Success)
+            {
+                return FormatUuid(match.Groups[1].Value);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Naive query-string parameter extractor that avoids a dependency on
+        /// <c>System.Web.HttpUtility</c> (not available in netstandard2.0 without an extra package).
+        /// </summary>
+        private static string GetQueryParam(string url, string paramName)
+        {
+            // Find the query string portion
+            var queryStart = url.IndexOf('?');
+            if (queryStart < 0)
+            {
+                return null;
+            }
+
+            // Strip off any fragment
+            var fragmentStart = url.IndexOf('#', queryStart);
+            var query = fragmentStart >= 0
+                ? url.Substring(queryStart + 1, fragmentStart - queryStart - 1)
+                : url.Substring(queryStart + 1);
+
+            foreach (var part in query.Split('&'))
+            {
+                var eq = part.IndexOf('=');
+                if (eq < 0)
+                {
+                    continue;
+                }
+
+                var key = Uri.UnescapeDataString(part.Substring(0, eq));
+                if (string.Equals(key, paramName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return Uri.UnescapeDataString(part.Substring(eq + 1));
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/Src/Notion.Client/Extensions/PaginationHelper.cs
+++ b/Src/Notion.Client/Extensions/PaginationHelper.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Notion.Client
+{
+    /// <summary>
+    /// Helper utilities for consuming Notion paginated list endpoints.
+    /// </summary>
+    public static class NotionPaginationHelper
+    {
+        /// <summary>
+        /// Iterates through every page returned by <paramref name="listFn"/> and
+        /// collects all results into a single <see cref="List{T}"/>.
+        /// </summary>
+        /// <typeparam name="T">The item type contained in each page.</typeparam>
+        /// <param name="listFn">
+        /// A delegate that accepts a <c>start_cursor</c> value (<see langword="null"/> for the
+        /// first page) and returns the corresponding <see cref="PaginatedList{T}"/>.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A token that can be used to cancel the operation before all pages are fetched.
+        /// </param>
+        /// <returns>A list containing every item across all pages.</returns>
+        public static async Task<List<T>> CollectPaginatedAsync<T>(
+            Func<string, Task<PaginatedList<T>>> listFn,
+            CancellationToken cancellationToken = default)
+        {
+            if (listFn == null)
+            {
+                throw new ArgumentNullException(nameof(listFn));
+            }
+
+            var results = new List<T>();
+            string cursor = null;
+
+            do
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var page = await listFn(cursor).ConfigureAwait(false);
+
+                if (page?.Results != null)
+                {
+                    results.AddRange(page.Results);
+                }
+
+                if (page == null || !page.HasMore)
+                {
+                    break;
+                }
+
+                cursor = page.NextCursor;
+            }
+            while (true);
+
+            return results;
+        }
+    }
+}

--- a/Src/Notion.Client/Models/Webhooks/CommentWebhookPayloads.cs
+++ b/Src/Notion.Client/Models/Webhooks/CommentWebhookPayloads.cs
@@ -1,0 +1,85 @@
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    /// <summary>
+    /// Payload for the "comment.created" webhook event.
+    /// </summary>
+    public class CommentCreatedWebhookPayload : WebhookPayload
+    {
+        /// <inheritdoc />
+        public override WebhookEventType Type => WebhookEventType.CommentCreated;
+
+        /// <summary>
+        /// The comment that triggered the event.
+        /// </summary>
+        [JsonProperty("entity")]
+        public WebhookCommentEntity Entity { get; set; }
+
+        /// <summary>
+        /// Additional event-specific data.
+        /// </summary>
+        [JsonProperty("data")]
+        public CommentEventData Data { get; set; }
+
+        /// <summary>
+        /// Event data shared by all comment webhook payload types.
+        /// </summary>
+        public class CommentEventData
+        {
+            /// <summary>
+            /// The parent of the comment (the page or block the comment is attached to).
+            /// </summary>
+            [JsonProperty("parent")]
+            public WebhookExternalBlock Parent { get; set; }
+
+            /// <summary>
+            /// The ID of the page containing the comment.
+            /// </summary>
+            [JsonProperty("page_id")]
+            public string PageId { get; set; }
+        }
+    }
+
+    /// <summary>
+    /// Payload for the "comment.updated" webhook event.
+    /// </summary>
+    public class CommentUpdatedWebhookPayload : WebhookPayload
+    {
+        /// <inheritdoc />
+        public override WebhookEventType Type => WebhookEventType.CommentUpdated;
+
+        /// <summary>
+        /// The comment that triggered the event.
+        /// </summary>
+        [JsonProperty("entity")]
+        public WebhookCommentEntity Entity { get; set; }
+
+        /// <summary>
+        /// Additional event-specific data.
+        /// </summary>
+        [JsonProperty("data")]
+        public CommentCreatedWebhookPayload.CommentEventData Data { get; set; }
+    }
+
+    /// <summary>
+    /// Payload for the "comment.deleted" webhook event.
+    /// </summary>
+    public class CommentDeletedWebhookPayload : WebhookPayload
+    {
+        /// <inheritdoc />
+        public override WebhookEventType Type => WebhookEventType.CommentDeleted;
+
+        /// <summary>
+        /// The comment that triggered the event.
+        /// </summary>
+        [JsonProperty("entity")]
+        public WebhookCommentEntity Entity { get; set; }
+
+        /// <summary>
+        /// Additional event-specific data.
+        /// </summary>
+        [JsonProperty("data")]
+        public CommentCreatedWebhookPayload.CommentEventData Data { get; set; }
+    }
+}

--- a/Src/Notion.Client/Models/Webhooks/DataSourceWebhookPayloads.cs
+++ b/Src/Notion.Client/Models/Webhooks/DataSourceWebhookPayloads.cs
@@ -1,0 +1,173 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    /// <summary>
+    /// Payload for the "data_source.content_updated" webhook event.
+    /// </summary>
+    public class DataSourceContentUpdatedWebhookPayload : WebhookPayload
+    {
+        /// <inheritdoc />
+        public override WebhookEventType Type => WebhookEventType.DataSourceContentUpdated;
+
+        /// <summary>
+        /// The data source that triggered the event.
+        /// </summary>
+        [JsonProperty("entity")]
+        public WebhookDatabaseEventEntity Entity { get; set; }
+
+        /// <summary>
+        /// Additional event-specific data.
+        /// </summary>
+        [JsonProperty("data")]
+        public DataSourceContentUpdatedData Data { get; set; }
+
+        public class DataSourceContentUpdatedData
+        {
+            /// <summary>
+            /// The parent of the entity whose content was updated.
+            /// </summary>
+            [JsonProperty("parent")]
+            public WebhookParentBlock Parent { get; set; }
+
+            /// <summary>
+            /// The blocks that were updated in this event.
+            /// </summary>
+            [JsonProperty("updated_blocks")]
+            public List<WebhookUpdatedBlock> UpdatedBlocks { get; set; }
+        }
+    }
+
+    /// <summary>
+    /// Payload for the "data_source.created" webhook event.
+    /// </summary>
+    public class DataSourceCreatedWebhookPayload : WebhookPayload
+    {
+        /// <inheritdoc />
+        public override WebhookEventType Type => WebhookEventType.DataSourceCreated;
+
+        /// <summary>
+        /// The data source that triggered the event.
+        /// </summary>
+        [JsonProperty("entity")]
+        public WebhookDatabaseEventEntity Entity { get; set; }
+
+        /// <summary>
+        /// Additional event-specific data.
+        /// </summary>
+        [JsonProperty("data")]
+        public DataSourceParentData Data { get; set; }
+    }
+
+    /// <summary>
+    /// Payload for the "data_source.deleted" webhook event.
+    /// </summary>
+    public class DataSourceDeletedWebhookPayload : WebhookPayload
+    {
+        /// <inheritdoc />
+        public override WebhookEventType Type => WebhookEventType.DataSourceDeleted;
+
+        /// <summary>
+        /// The data source that triggered the event.
+        /// </summary>
+        [JsonProperty("entity")]
+        public WebhookDatabaseEventEntity Entity { get; set; }
+
+        /// <summary>
+        /// Additional event-specific data.
+        /// </summary>
+        [JsonProperty("data")]
+        public DataSourceParentData Data { get; set; }
+    }
+
+    /// <summary>
+    /// Payload for the "data_source.moved" webhook event.
+    /// </summary>
+    public class DataSourceMovedWebhookPayload : WebhookPayload
+    {
+        /// <inheritdoc />
+        public override WebhookEventType Type => WebhookEventType.DataSourceMoved;
+
+        /// <summary>
+        /// The data source that triggered the event.
+        /// </summary>
+        [JsonProperty("entity")]
+        public WebhookDatabaseEventEntity Entity { get; set; }
+
+        /// <summary>
+        /// Additional event-specific data.
+        /// </summary>
+        [JsonProperty("data")]
+        public DataSourceParentData Data { get; set; }
+    }
+
+    /// <summary>
+    /// Payload for the "data_source.schema_updated" webhook event.
+    /// </summary>
+    public class DataSourceSchemaUpdatedWebhookPayload : WebhookPayload
+    {
+        /// <inheritdoc />
+        public override WebhookEventType Type => WebhookEventType.DataSourceSchemaUpdated;
+
+        /// <summary>
+        /// The data source that triggered the event.
+        /// </summary>
+        [JsonProperty("entity")]
+        public WebhookDatabaseEventEntity Entity { get; set; }
+
+        /// <summary>
+        /// Additional event-specific data.
+        /// </summary>
+        [JsonProperty("data")]
+        public DataSourceSchemaUpdatedData Data { get; set; }
+
+        public class DataSourceSchemaUpdatedData
+        {
+            /// <summary>
+            /// The parent of the data source whose schema was updated.
+            /// </summary>
+            [JsonProperty("parent")]
+            public WebhookParentBlock Parent { get; set; }
+
+            /// <summary>
+            /// The database properties that were created, updated, or deleted.
+            /// </summary>
+            [JsonProperty("updated_properties")]
+            public List<WebhookSchemaUpdatedProperty> UpdatedProperties { get; set; }
+        }
+    }
+
+    /// <summary>
+    /// Payload for the "data_source.undeleted" webhook event.
+    /// </summary>
+    public class DataSourceUndeletedWebhookPayload : WebhookPayload
+    {
+        /// <inheritdoc />
+        public override WebhookEventType Type => WebhookEventType.DataSourceUndeleted;
+
+        /// <summary>
+        /// The data source that triggered the event.
+        /// </summary>
+        [JsonProperty("entity")]
+        public WebhookDatabaseEventEntity Entity { get; set; }
+
+        /// <summary>
+        /// Additional event-specific data.
+        /// </summary>
+        [JsonProperty("data")]
+        public DataSourceParentData Data { get; set; }
+    }
+
+    /// <summary>
+    /// Shared data class for data source events that only carry a parent.
+    /// </summary>
+    public class DataSourceParentData
+    {
+        /// <summary>
+        /// The parent of the entity that triggered the event.
+        /// </summary>
+        [JsonProperty("parent")]
+        public WebhookParentBlock Parent { get; set; }
+    }
+}

--- a/Src/Notion.Client/Models/Webhooks/DatabaseWebhookPayloads.cs
+++ b/Src/Notion.Client/Models/Webhooks/DatabaseWebhookPayloads.cs
@@ -1,0 +1,173 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    /// <summary>
+    /// Payload for the "database.content_updated" webhook event.
+    /// </summary>
+    public class DatabaseContentUpdatedWebhookPayload : WebhookPayload
+    {
+        /// <inheritdoc />
+        public override WebhookEventType Type => WebhookEventType.DatabaseContentUpdated;
+
+        /// <summary>
+        /// The database that triggered the event.
+        /// </summary>
+        [JsonProperty("entity")]
+        public WebhookDatabaseEventEntity Entity { get; set; }
+
+        /// <summary>
+        /// Additional event-specific data.
+        /// </summary>
+        [JsonProperty("data")]
+        public DatabaseContentUpdatedData Data { get; set; }
+
+        public class DatabaseContentUpdatedData
+        {
+            /// <summary>
+            /// The parent of the entity whose content was updated.
+            /// </summary>
+            [JsonProperty("parent")]
+            public WebhookParentBlock Parent { get; set; }
+
+            /// <summary>
+            /// The blocks that were updated in this event.
+            /// </summary>
+            [JsonProperty("updated_blocks")]
+            public List<WebhookUpdatedBlock> UpdatedBlocks { get; set; }
+        }
+    }
+
+    /// <summary>
+    /// Payload for the "database.created" webhook event.
+    /// </summary>
+    public class DatabaseCreatedWebhookPayload : WebhookPayload
+    {
+        /// <inheritdoc />
+        public override WebhookEventType Type => WebhookEventType.DatabaseCreated;
+
+        /// <summary>
+        /// The database that triggered the event.
+        /// </summary>
+        [JsonProperty("entity")]
+        public WebhookDatabaseEventEntity Entity { get; set; }
+
+        /// <summary>
+        /// Additional event-specific data.
+        /// </summary>
+        [JsonProperty("data")]
+        public DatabaseParentData Data { get; set; }
+    }
+
+    /// <summary>
+    /// Payload for the "database.deleted" webhook event.
+    /// </summary>
+    public class DatabaseDeletedWebhookPayload : WebhookPayload
+    {
+        /// <inheritdoc />
+        public override WebhookEventType Type => WebhookEventType.DatabaseDeleted;
+
+        /// <summary>
+        /// The database that triggered the event.
+        /// </summary>
+        [JsonProperty("entity")]
+        public WebhookDatabaseEventEntity Entity { get; set; }
+
+        /// <summary>
+        /// Additional event-specific data.
+        /// </summary>
+        [JsonProperty("data")]
+        public DatabaseParentData Data { get; set; }
+    }
+
+    /// <summary>
+    /// Payload for the "database.moved" webhook event.
+    /// </summary>
+    public class DatabaseMovedWebhookPayload : WebhookPayload
+    {
+        /// <inheritdoc />
+        public override WebhookEventType Type => WebhookEventType.DatabaseMoved;
+
+        /// <summary>
+        /// The database that triggered the event.
+        /// </summary>
+        [JsonProperty("entity")]
+        public WebhookDatabaseEventEntity Entity { get; set; }
+
+        /// <summary>
+        /// Additional event-specific data.
+        /// </summary>
+        [JsonProperty("data")]
+        public DatabaseParentData Data { get; set; }
+    }
+
+    /// <summary>
+    /// Payload for the "database.schema_updated" webhook event.
+    /// </summary>
+    public class DatabaseSchemaUpdatedWebhookPayload : WebhookPayload
+    {
+        /// <inheritdoc />
+        public override WebhookEventType Type => WebhookEventType.DatabaseSchemaUpdated;
+
+        /// <summary>
+        /// The database that triggered the event.
+        /// </summary>
+        [JsonProperty("entity")]
+        public WebhookDatabaseEventEntity Entity { get; set; }
+
+        /// <summary>
+        /// Additional event-specific data.
+        /// </summary>
+        [JsonProperty("data")]
+        public DatabaseSchemaUpdatedData Data { get; set; }
+
+        public class DatabaseSchemaUpdatedData
+        {
+            /// <summary>
+            /// The parent of the database whose schema was updated.
+            /// </summary>
+            [JsonProperty("parent")]
+            public WebhookParentBlock Parent { get; set; }
+
+            /// <summary>
+            /// The database properties that were created, updated, or deleted.
+            /// </summary>
+            [JsonProperty("updated_properties")]
+            public List<WebhookSchemaUpdatedProperty> UpdatedProperties { get; set; }
+        }
+    }
+
+    /// <summary>
+    /// Payload for the "database.undeleted" webhook event.
+    /// </summary>
+    public class DatabaseUndeletedWebhookPayload : WebhookPayload
+    {
+        /// <inheritdoc />
+        public override WebhookEventType Type => WebhookEventType.DatabaseUndeleted;
+
+        /// <summary>
+        /// The database that triggered the event.
+        /// </summary>
+        [JsonProperty("entity")]
+        public WebhookDatabaseEventEntity Entity { get; set; }
+
+        /// <summary>
+        /// Additional event-specific data.
+        /// </summary>
+        [JsonProperty("data")]
+        public DatabaseParentData Data { get; set; }
+    }
+
+    /// <summary>
+    /// Shared data class for database events that only carry a parent.
+    /// </summary>
+    public class DatabaseParentData
+    {
+        /// <summary>
+        /// The parent of the entity that triggered the event.
+        /// </summary>
+        [JsonProperty("parent")]
+        public WebhookParentBlock Parent { get; set; }
+    }
+}

--- a/Src/Notion.Client/Models/Webhooks/FileUploadWebhookPayloads.cs
+++ b/Src/Notion.Client/Models/Webhooks/FileUploadWebhookPayloads.cs
@@ -1,0 +1,81 @@
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    /// <summary>
+    /// Payload for the "file_upload.completed" webhook event.
+    /// </summary>
+    public class FileUploadCompletedWebhookPayload : WebhookPayload
+    {
+        /// <inheritdoc />
+        public override WebhookEventType Type => WebhookEventType.FileUploadCompleted;
+
+        /// <summary>
+        /// The file upload that triggered the event.
+        /// </summary>
+        [JsonProperty("entity")]
+        public WebhookFileUploadEntity Entity { get; set; }
+    }
+
+    /// <summary>
+    /// Payload for the "file_upload.created" webhook event.
+    /// </summary>
+    public class FileUploadCreatedWebhookPayload : WebhookPayload
+    {
+        /// <inheritdoc />
+        public override WebhookEventType Type => WebhookEventType.FileUploadCreated;
+
+        /// <summary>
+        /// The file upload that triggered the event.
+        /// </summary>
+        [JsonProperty("entity")]
+        public WebhookFileUploadEntity Entity { get; set; }
+    }
+
+    /// <summary>
+    /// Payload for the "file_upload.expired" webhook event.
+    /// </summary>
+    public class FileUploadExpiredWebhookPayload : WebhookPayload
+    {
+        /// <inheritdoc />
+        public override WebhookEventType Type => WebhookEventType.FileUploadExpired;
+
+        /// <summary>
+        /// The file upload that triggered the event.
+        /// </summary>
+        [JsonProperty("entity")]
+        public WebhookFileUploadEntity Entity { get; set; }
+    }
+
+    /// <summary>
+    /// Payload for the "file_upload.upload_failed" webhook event.
+    /// </summary>
+    public class FileUploadUploadFailedWebhookPayload : WebhookPayload
+    {
+        /// <inheritdoc />
+        public override WebhookEventType Type => WebhookEventType.FileUploadUploadFailed;
+
+        /// <summary>
+        /// The file upload that triggered the event.
+        /// </summary>
+        [JsonProperty("entity")]
+        public WebhookFileUploadEntity Entity { get; set; }
+
+        /// <summary>
+        /// Additional event-specific data.
+        /// </summary>
+        [JsonProperty("data")]
+        public FileUploadFailedData Data { get; set; }
+
+        public class FileUploadFailedData
+        {
+            /// <summary>
+            /// The result of the file import attempt.
+            /// Discriminated by "type": "success" → <see cref="FileImportSuccessResult"/>,
+            /// "error" → <see cref="FileImportErrorResult"/>.
+            /// </summary>
+            [JsonProperty("file_import_result")]
+            public FileImportResult FileImportResult { get; set; }
+        }
+    }
+}

--- a/Src/Notion.Client/Models/Webhooks/PageWebhookPayloads.cs
+++ b/Src/Notion.Client/Models/Webhooks/PageWebhookPayloads.cs
@@ -1,0 +1,251 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    /// <summary>
+    /// Payload for the "page.content_updated" webhook event.
+    /// </summary>
+    public class PageContentUpdatedWebhookPayload : WebhookPayload
+    {
+        /// <inheritdoc />
+        public override WebhookEventType Type => WebhookEventType.PageContentUpdated;
+
+        /// <summary>
+        /// The page that triggered the event.
+        /// </summary>
+        [JsonProperty("entity")]
+        public WebhookPageEntity Entity { get; set; }
+
+        /// <summary>
+        /// Additional event-specific data.
+        /// </summary>
+        [JsonProperty("data")]
+        public PageContentUpdatedData Data { get; set; }
+
+        public class PageContentUpdatedData
+        {
+            /// <summary>
+            /// The parent of the entity whose content was updated.
+            /// </summary>
+            [JsonProperty("parent")]
+            public WebhookParentBlock Parent { get; set; }
+
+            /// <summary>
+            /// The blocks that were updated in this event.
+            /// </summary>
+            [JsonProperty("updated_blocks")]
+            public List<WebhookUpdatedBlock> UpdatedBlocks { get; set; }
+        }
+    }
+
+    /// <summary>
+    /// Payload for the "page.created" webhook event.
+    /// </summary>
+    public class PageCreatedWebhookPayload : WebhookPayload
+    {
+        /// <inheritdoc />
+        public override WebhookEventType Type => WebhookEventType.PageCreated;
+
+        /// <summary>
+        /// The page that triggered the event.
+        /// </summary>
+        [JsonProperty("entity")]
+        public WebhookPageEntity Entity { get; set; }
+
+        /// <summary>
+        /// Additional event-specific data.
+        /// </summary>
+        [JsonProperty("data")]
+        public PageParentData Data { get; set; }
+    }
+
+    /// <summary>
+    /// Payload for the "page.deleted" webhook event.
+    /// </summary>
+    public class PageDeletedWebhookPayload : WebhookPayload
+    {
+        /// <inheritdoc />
+        public override WebhookEventType Type => WebhookEventType.PageDeleted;
+
+        /// <summary>
+        /// The page that triggered the event.
+        /// </summary>
+        [JsonProperty("entity")]
+        public WebhookPageEntity Entity { get; set; }
+
+        /// <summary>
+        /// Additional event-specific data.
+        /// </summary>
+        [JsonProperty("data")]
+        public PageParentData Data { get; set; }
+    }
+
+    /// <summary>
+    /// Payload for the "page.locked" webhook event.
+    /// </summary>
+    public class PageLockedWebhookPayload : WebhookPayload
+    {
+        /// <inheritdoc />
+        public override WebhookEventType Type => WebhookEventType.PageLocked;
+
+        /// <summary>
+        /// The page that triggered the event.
+        /// </summary>
+        [JsonProperty("entity")]
+        public WebhookPageEntity Entity { get; set; }
+
+        /// <summary>
+        /// Additional event-specific data.
+        /// </summary>
+        [JsonProperty("data")]
+        public PageParentData Data { get; set; }
+    }
+
+    /// <summary>
+    /// Payload for the "page.moved" webhook event.
+    /// </summary>
+    public class PageMovedWebhookPayload : WebhookPayload
+    {
+        /// <inheritdoc />
+        public override WebhookEventType Type => WebhookEventType.PageMoved;
+
+        /// <summary>
+        /// The page that triggered the event.
+        /// </summary>
+        [JsonProperty("entity")]
+        public WebhookPageEntity Entity { get; set; }
+
+        /// <summary>
+        /// Additional event-specific data.
+        /// </summary>
+        [JsonProperty("data")]
+        public PageParentData Data { get; set; }
+    }
+
+    /// <summary>
+    /// Payload for the "page.properties_updated" webhook event.
+    /// </summary>
+    public class PagePropertiesUpdatedWebhookPayload : WebhookPayload
+    {
+        /// <inheritdoc />
+        public override WebhookEventType Type => WebhookEventType.PagePropertiesUpdated;
+
+        /// <summary>
+        /// The page that triggered the event.
+        /// </summary>
+        [JsonProperty("entity")]
+        public WebhookPageEntity Entity { get; set; }
+
+        /// <summary>
+        /// Additional event-specific data.
+        /// </summary>
+        [JsonProperty("data")]
+        public PagePropertiesUpdatedData Data { get; set; }
+
+        public class PagePropertiesUpdatedData
+        {
+            /// <summary>
+            /// The parent of the page whose properties were updated.
+            /// </summary>
+            [JsonProperty("parent")]
+            public WebhookParentBlock Parent { get; set; }
+
+            /// <summary>
+            /// The IDs of the properties that were updated.
+            /// </summary>
+            [JsonProperty("updated_properties")]
+            public List<string> UpdatedProperties { get; set; }
+        }
+    }
+
+    /// <summary>
+    /// Payload for the "page.transcription_block.transcript_deleted" webhook event.
+    /// </summary>
+    public class PageTranscriptionBlockTranscriptDeletedWebhookPayload : WebhookPayload
+    {
+        /// <inheritdoc />
+        public override WebhookEventType Type => WebhookEventType.PageTranscriptionBlockTranscriptDeleted;
+
+        /// <summary>
+        /// The page that triggered the event.
+        /// </summary>
+        [JsonProperty("entity")]
+        public WebhookPageEntity Entity { get; set; }
+
+        /// <summary>
+        /// Additional event-specific data.
+        /// </summary>
+        [JsonProperty("data")]
+        public PageTranscriptDeletedData Data { get; set; }
+
+        public class PageTranscriptDeletedData
+        {
+            /// <summary>
+            /// The block that contained the deleted transcript.
+            /// </summary>
+            [JsonProperty("target")]
+            public WebhookExternalBlock Target { get; set; }
+
+            /// <summary>
+            /// The ID of the deleted transcript, or <c>null</c> if not available.
+            /// </summary>
+            [JsonProperty("transcript_id")]
+            public string TranscriptId { get; set; }
+        }
+    }
+
+    /// <summary>
+    /// Payload for the "page.undeleted" webhook event.
+    /// </summary>
+    public class PageUndeletedWebhookPayload : WebhookPayload
+    {
+        /// <inheritdoc />
+        public override WebhookEventType Type => WebhookEventType.PageUndeleted;
+
+        /// <summary>
+        /// The page that triggered the event.
+        /// </summary>
+        [JsonProperty("entity")]
+        public WebhookPageEntity Entity { get; set; }
+
+        /// <summary>
+        /// Additional event-specific data.
+        /// </summary>
+        [JsonProperty("data")]
+        public PageParentData Data { get; set; }
+    }
+
+    /// <summary>
+    /// Payload for the "page.unlocked" webhook event.
+    /// </summary>
+    public class PageUnlockedWebhookPayload : WebhookPayload
+    {
+        /// <inheritdoc />
+        public override WebhookEventType Type => WebhookEventType.PageUnlocked;
+
+        /// <summary>
+        /// The page that triggered the event.
+        /// </summary>
+        [JsonProperty("entity")]
+        public WebhookPageEntity Entity { get; set; }
+
+        /// <summary>
+        /// Additional event-specific data.
+        /// </summary>
+        [JsonProperty("data")]
+        public PageParentData Data { get; set; }
+    }
+
+    /// <summary>
+    /// Shared data class for page events that only carry a parent.
+    /// </summary>
+    public class PageParentData
+    {
+        /// <summary>
+        /// The parent of the entity that triggered the event.
+        /// </summary>
+        [JsonProperty("parent")]
+        public WebhookParentBlock Parent { get; set; }
+    }
+}

--- a/Src/Notion.Client/Models/Webhooks/UnknownWebhookPayload.cs
+++ b/Src/Notion.Client/Models/Webhooks/UnknownWebhookPayload.cs
@@ -1,0 +1,10 @@
+namespace Notion.Client
+{
+    /// <summary>
+    /// Fallback payload type for webhook events with an unrecognized "type" value.
+    /// The raw type string is accessible via <see cref="WebhookPayload.Type"/>.
+    /// </summary>
+    public class UnknownWebhookPayload : WebhookPayload
+    {
+    }
+}

--- a/Src/Notion.Client/Models/Webhooks/ViewWebhookPayloads.cs
+++ b/Src/Notion.Client/Models/Webhooks/ViewWebhookPayloads.cs
@@ -1,0 +1,110 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    /// <summary>
+    /// Payload for the "view.created" webhook event.
+    /// </summary>
+    public class ViewCreatedWebhookPayload : WebhookPayload
+    {
+        /// <inheritdoc />
+        public override WebhookEventType Type => WebhookEventType.ViewCreated;
+
+        /// <summary>
+        /// The view that triggered the event.
+        /// </summary>
+        [JsonProperty("entity")]
+        public WebhookViewEntity Entity { get; set; }
+
+        /// <summary>
+        /// Additional event-specific data.
+        /// </summary>
+        [JsonProperty("data")]
+        public ViewCreatedData Data { get; set; }
+
+        public class ViewCreatedData
+        {
+            /// <summary>
+            /// The parent of the created view.
+            /// </summary>
+            [JsonProperty("parent")]
+            public WebhookParentBlock Parent { get; set; }
+
+            /// <summary>
+            /// The type of the created view (e.g. "table", "board", "list", "calendar", "gallery", "timeline").
+            /// </summary>
+            [JsonProperty("view_type")]
+            public string ViewType { get; set; }
+        }
+    }
+
+    /// <summary>
+    /// Payload for the "view.deleted" webhook event.
+    /// </summary>
+    public class ViewDeletedWebhookPayload : WebhookPayload
+    {
+        /// <inheritdoc />
+        public override WebhookEventType Type => WebhookEventType.ViewDeleted;
+
+        /// <summary>
+        /// The view that triggered the event.
+        /// </summary>
+        [JsonProperty("entity")]
+        public WebhookViewEntity Entity { get; set; }
+
+        /// <summary>
+        /// Additional event-specific data.
+        /// </summary>
+        [JsonProperty("data")]
+        public ViewParentData Data { get; set; }
+    }
+
+    /// <summary>
+    /// Payload for the "view.updated" webhook event.
+    /// </summary>
+    public class ViewUpdatedWebhookPayload : WebhookPayload
+    {
+        /// <inheritdoc />
+        public override WebhookEventType Type => WebhookEventType.ViewUpdated;
+
+        /// <summary>
+        /// The view that triggered the event.
+        /// </summary>
+        [JsonProperty("entity")]
+        public WebhookViewEntity Entity { get; set; }
+
+        /// <summary>
+        /// Additional event-specific data.
+        /// </summary>
+        [JsonProperty("data")]
+        public ViewUpdatedData Data { get; set; }
+
+        public class ViewUpdatedData
+        {
+            /// <summary>
+            /// The parent of the updated view.
+            /// </summary>
+            [JsonProperty("parent")]
+            public WebhookParentBlock Parent { get; set; }
+
+            /// <summary>
+            /// The fields of the view that were updated.
+            /// </summary>
+            [JsonProperty("updated_fields")]
+            public List<string> UpdatedFields { get; set; }
+        }
+    }
+
+    /// <summary>
+    /// Shared data class for view events that only carry a parent.
+    /// </summary>
+    public class ViewParentData
+    {
+        /// <summary>
+        /// The parent of the entity that triggered the event.
+        /// </summary>
+        [JsonProperty("parent")]
+        public WebhookParentBlock Parent { get; set; }
+    }
+}

--- a/Src/Notion.Client/Models/Webhooks/WebhookAuthor.cs
+++ b/Src/Notion.Client/Models/Webhooks/WebhookAuthor.cs
@@ -1,0 +1,22 @@
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    /// <summary>
+    /// Represents a user or bot that performed a webhook-triggering action.
+    /// </summary>
+    public class WebhookAuthor
+    {
+        /// <summary>
+        /// The ID of the user or bot.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// The type of the author. Either "person" or "bot".
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+    }
+}

--- a/Src/Notion.Client/Models/Webhooks/WebhookEntity.cs
+++ b/Src/Notion.Client/Models/Webhooks/WebhookEntity.cs
@@ -1,0 +1,94 @@
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    /// <summary>
+    /// Represents a comment entity in a webhook event.
+    /// </summary>
+    public class WebhookCommentEntity
+    {
+        /// <summary>
+        /// Always "comment".
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        /// <summary>
+        /// The ID of the comment that triggered the event.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+    }
+
+    /// <summary>
+    /// Represents a page entity in a webhook event.
+    /// </summary>
+    public class WebhookPageEntity
+    {
+        /// <summary>
+        /// Always "page".
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        /// <summary>
+        /// The ID of the page that triggered the event.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+    }
+
+    /// <summary>
+    /// Represents a database or data source entity in a webhook event.
+    /// </summary>
+    public class WebhookDatabaseEventEntity
+    {
+        /// <summary>
+        /// The ID of the database or data source that triggered the event.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// The type of entity. For linked databases, this is "block". Can be "block", "database", or "data_source".
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+    }
+
+    /// <summary>
+    /// Represents a file upload entity in a webhook event.
+    /// </summary>
+    public class WebhookFileUploadEntity
+    {
+        /// <summary>
+        /// Always "file_upload".
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        /// <summary>
+        /// The ID of the file upload that triggered the event.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+    }
+
+    /// <summary>
+    /// Represents a view entity in a webhook event.
+    /// </summary>
+    public class WebhookViewEntity
+    {
+        /// <summary>
+        /// The ID of the view that triggered the event.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// Always "view".
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+    }
+}

--- a/Src/Notion.Client/Models/Webhooks/WebhookEventType.cs
+++ b/Src/Notion.Client/Models/Webhooks/WebhookEventType.cs
@@ -1,0 +1,106 @@
+using System;
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    /// <summary>
+    /// Represents the type of a Notion webhook event.
+    /// New values introduced by Notion are preserved as-is rather than causing a deserialization failure.
+    /// Use the <c>const string</c> members (e.g. <see cref="CommentCreatedValue"/>) when referencing a value
+    /// in a <c>[JsonSubtypes.KnownSubType]</c> attribute; use the <c>static readonly</c> fields
+    /// (e.g. <see cref="CommentCreated"/>) everywhere else.
+    /// </summary>
+    [JsonConverter(typeof(ExtensibleEnumConverter<WebhookEventType>))]
+    public readonly struct WebhookEventType : IEquatable<WebhookEventType>
+    {
+        private readonly string _value;
+
+        public WebhookEventType(string value) => _value = value;
+
+        public const string CommentCreatedValue = "comment.created";
+        public const string CommentUpdatedValue = "comment.updated";
+        public const string CommentDeletedValue = "comment.deleted";
+
+        public const string DataSourceContentUpdatedValue = "data_source.content_updated";
+        public const string DataSourceCreatedValue = "data_source.created";
+        public const string DataSourceDeletedValue = "data_source.deleted";
+        public const string DataSourceMovedValue = "data_source.moved";
+        public const string DataSourceSchemaUpdatedValue = "data_source.schema_updated";
+        public const string DataSourceUndeletedValue = "data_source.undeleted";
+
+        public const string DatabaseContentUpdatedValue = "database.content_updated";
+        public const string DatabaseCreatedValue = "database.created";
+        public const string DatabaseDeletedValue = "database.deleted";
+        public const string DatabaseMovedValue = "database.moved";
+        public const string DatabaseSchemaUpdatedValue = "database.schema_updated";
+        public const string DatabaseUndeletedValue = "database.undeleted";
+
+        public const string FileUploadCompletedValue = "file_upload.completed";
+        public const string FileUploadCreatedValue = "file_upload.created";
+        public const string FileUploadExpiredValue = "file_upload.expired";
+        public const string FileUploadUploadFailedValue = "file_upload.upload_failed";
+
+        public const string PageContentUpdatedValue = "page.content_updated";
+        public const string PageCreatedValue = "page.created";
+        public const string PageDeletedValue = "page.deleted";
+        public const string PageLockedValue = "page.locked";
+        public const string PageMovedValue = "page.moved";
+        public const string PagePropertiesUpdatedValue = "page.properties_updated";
+        public const string PageTranscriptionBlockTranscriptDeletedValue = "page.transcription_block.transcript_deleted";
+        public const string PageUndeletedValue = "page.undeleted";
+        public const string PageUnlockedValue = "page.unlocked";
+
+        public const string ViewCreatedValue = "view.created";
+        public const string ViewDeletedValue = "view.deleted";
+        public const string ViewUpdatedValue = "view.updated";
+
+        public static readonly WebhookEventType CommentCreated = new WebhookEventType(CommentCreatedValue);
+        public static readonly WebhookEventType CommentUpdated = new WebhookEventType(CommentUpdatedValue);
+        public static readonly WebhookEventType CommentDeleted = new WebhookEventType(CommentDeletedValue);
+
+        public static readonly WebhookEventType DataSourceContentUpdated = new WebhookEventType(DataSourceContentUpdatedValue);
+        public static readonly WebhookEventType DataSourceCreated = new WebhookEventType(DataSourceCreatedValue);
+        public static readonly WebhookEventType DataSourceDeleted = new WebhookEventType(DataSourceDeletedValue);
+        public static readonly WebhookEventType DataSourceMoved = new WebhookEventType(DataSourceMovedValue);
+        public static readonly WebhookEventType DataSourceSchemaUpdated = new WebhookEventType(DataSourceSchemaUpdatedValue);
+        public static readonly WebhookEventType DataSourceUndeleted = new WebhookEventType(DataSourceUndeletedValue);
+
+        public static readonly WebhookEventType DatabaseContentUpdated = new WebhookEventType(DatabaseContentUpdatedValue);
+        public static readonly WebhookEventType DatabaseCreated = new WebhookEventType(DatabaseCreatedValue);
+        public static readonly WebhookEventType DatabaseDeleted = new WebhookEventType(DatabaseDeletedValue);
+        public static readonly WebhookEventType DatabaseMoved = new WebhookEventType(DatabaseMovedValue);
+        public static readonly WebhookEventType DatabaseSchemaUpdated = new WebhookEventType(DatabaseSchemaUpdatedValue);
+        public static readonly WebhookEventType DatabaseUndeleted = new WebhookEventType(DatabaseUndeletedValue);
+
+        public static readonly WebhookEventType FileUploadCompleted = new WebhookEventType(FileUploadCompletedValue);
+        public static readonly WebhookEventType FileUploadCreated = new WebhookEventType(FileUploadCreatedValue);
+        public static readonly WebhookEventType FileUploadExpired = new WebhookEventType(FileUploadExpiredValue);
+        public static readonly WebhookEventType FileUploadUploadFailed = new WebhookEventType(FileUploadUploadFailedValue);
+
+        public static readonly WebhookEventType PageContentUpdated = new WebhookEventType(PageContentUpdatedValue);
+        public static readonly WebhookEventType PageCreated = new WebhookEventType(PageCreatedValue);
+        public static readonly WebhookEventType PageDeleted = new WebhookEventType(PageDeletedValue);
+        public static readonly WebhookEventType PageLocked = new WebhookEventType(PageLockedValue);
+        public static readonly WebhookEventType PageMoved = new WebhookEventType(PageMovedValue);
+        public static readonly WebhookEventType PagePropertiesUpdated = new WebhookEventType(PagePropertiesUpdatedValue);
+        public static readonly WebhookEventType PageTranscriptionBlockTranscriptDeleted = new WebhookEventType(PageTranscriptionBlockTranscriptDeletedValue);
+        public static readonly WebhookEventType PageUndeleted = new WebhookEventType(PageUndeletedValue);
+        public static readonly WebhookEventType PageUnlocked = new WebhookEventType(PageUnlockedValue);
+
+        public static readonly WebhookEventType ViewCreated = new WebhookEventType(ViewCreatedValue);
+        public static readonly WebhookEventType ViewDeleted = new WebhookEventType(ViewDeletedValue);
+        public static readonly WebhookEventType ViewUpdated = new WebhookEventType(ViewUpdatedValue);
+
+        public static implicit operator WebhookEventType(string value) => new WebhookEventType(value);
+
+        public static bool operator ==(WebhookEventType left, WebhookEventType right) => left.Equals(right);
+        public static bool operator !=(WebhookEventType left, WebhookEventType right) => !left.Equals(right);
+
+        public bool Equals(WebhookEventType other) =>
+            string.Equals(_value, other._value, StringComparison.Ordinal);
+
+        public override bool Equals(object obj) => obj is WebhookEventType other && Equals(other);
+        public override int GetHashCode() => _value?.GetHashCode() ?? 0;
+        public override string ToString() => _value ?? string.Empty;
+    }
+}

--- a/Src/Notion.Client/Models/Webhooks/WebhookParent.cs
+++ b/Src/Notion.Client/Models/Webhooks/WebhookParent.cs
@@ -1,0 +1,46 @@
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    /// <summary>
+    /// Represents a parent block in a webhook event, including workspace-level parents.
+    /// </summary>
+    public class WebhookParentBlock
+    {
+        /// <summary>
+        /// The ID of the parent.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// The type of the parent. One of "space", "block", "page", "database", "team", or "agent".
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        /// <summary>
+        /// The data source ID of the parent, if applicable.
+        /// </summary>
+        [JsonProperty("data_source_id")]
+        public string DataSourceId { get; set; }
+    }
+
+    /// <summary>
+    /// Represents an external block reference (e.g., the parent of a comment).
+    /// </summary>
+    public class WebhookExternalBlock
+    {
+        /// <summary>
+        /// The ID of the parent.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// The type of the parent. One of "page", "database", or "block".
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+    }
+}

--- a/Src/Notion.Client/Models/Webhooks/WebhookPayload.cs
+++ b/Src/Notion.Client/Models/Webhooks/WebhookPayload.cs
@@ -1,0 +1,113 @@
+using System.Collections.Generic;
+using JsonSubTypes;
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    /// <summary>
+    /// Base class for all Notion webhook event payloads.
+    /// Discriminated on the "type" field; unknown types deserialize as <see cref="UnknownWebhookPayload"/>.
+    /// </summary>
+    [JsonConverter(typeof(JsonSubtypes), "type")]
+    [JsonSubtypes.KnownSubTypeAttribute(typeof(CommentCreatedWebhookPayload), WebhookEventType.CommentCreatedValue)]
+    [JsonSubtypes.KnownSubTypeAttribute(typeof(CommentUpdatedWebhookPayload), WebhookEventType.CommentUpdatedValue)]
+    [JsonSubtypes.KnownSubTypeAttribute(typeof(CommentDeletedWebhookPayload), WebhookEventType.CommentDeletedValue)]
+    [JsonSubtypes.KnownSubTypeAttribute(typeof(DataSourceContentUpdatedWebhookPayload), WebhookEventType.DataSourceContentUpdatedValue)]
+    [JsonSubtypes.KnownSubTypeAttribute(typeof(DataSourceCreatedWebhookPayload), WebhookEventType.DataSourceCreatedValue)]
+    [JsonSubtypes.KnownSubTypeAttribute(typeof(DataSourceDeletedWebhookPayload), WebhookEventType.DataSourceDeletedValue)]
+    [JsonSubtypes.KnownSubTypeAttribute(typeof(DataSourceMovedWebhookPayload), WebhookEventType.DataSourceMovedValue)]
+    [JsonSubtypes.KnownSubTypeAttribute(typeof(DataSourceSchemaUpdatedWebhookPayload), WebhookEventType.DataSourceSchemaUpdatedValue)]
+    [JsonSubtypes.KnownSubTypeAttribute(typeof(DataSourceUndeletedWebhookPayload), WebhookEventType.DataSourceUndeletedValue)]
+    [JsonSubtypes.KnownSubTypeAttribute(typeof(DatabaseContentUpdatedWebhookPayload), WebhookEventType.DatabaseContentUpdatedValue)]
+    [JsonSubtypes.KnownSubTypeAttribute(typeof(DatabaseCreatedWebhookPayload), WebhookEventType.DatabaseCreatedValue)]
+    [JsonSubtypes.KnownSubTypeAttribute(typeof(DatabaseDeletedWebhookPayload), WebhookEventType.DatabaseDeletedValue)]
+    [JsonSubtypes.KnownSubTypeAttribute(typeof(DatabaseMovedWebhookPayload), WebhookEventType.DatabaseMovedValue)]
+    [JsonSubtypes.KnownSubTypeAttribute(typeof(DatabaseSchemaUpdatedWebhookPayload), WebhookEventType.DatabaseSchemaUpdatedValue)]
+    [JsonSubtypes.KnownSubTypeAttribute(typeof(DatabaseUndeletedWebhookPayload), WebhookEventType.DatabaseUndeletedValue)]
+    [JsonSubtypes.KnownSubTypeAttribute(typeof(FileUploadCompletedWebhookPayload), WebhookEventType.FileUploadCompletedValue)]
+    [JsonSubtypes.KnownSubTypeAttribute(typeof(FileUploadCreatedWebhookPayload), WebhookEventType.FileUploadCreatedValue)]
+    [JsonSubtypes.KnownSubTypeAttribute(typeof(FileUploadExpiredWebhookPayload), WebhookEventType.FileUploadExpiredValue)]
+    [JsonSubtypes.KnownSubTypeAttribute(typeof(FileUploadUploadFailedWebhookPayload), WebhookEventType.FileUploadUploadFailedValue)]
+    [JsonSubtypes.KnownSubTypeAttribute(typeof(PageContentUpdatedWebhookPayload), WebhookEventType.PageContentUpdatedValue)]
+    [JsonSubtypes.KnownSubTypeAttribute(typeof(PageCreatedWebhookPayload), WebhookEventType.PageCreatedValue)]
+    [JsonSubtypes.KnownSubTypeAttribute(typeof(PageDeletedWebhookPayload), WebhookEventType.PageDeletedValue)]
+    [JsonSubtypes.KnownSubTypeAttribute(typeof(PageLockedWebhookPayload), WebhookEventType.PageLockedValue)]
+    [JsonSubtypes.KnownSubTypeAttribute(typeof(PageMovedWebhookPayload), WebhookEventType.PageMovedValue)]
+    [JsonSubtypes.KnownSubTypeAttribute(typeof(PagePropertiesUpdatedWebhookPayload), WebhookEventType.PagePropertiesUpdatedValue)]
+    [JsonSubtypes.KnownSubTypeAttribute(typeof(PageTranscriptionBlockTranscriptDeletedWebhookPayload), WebhookEventType.PageTranscriptionBlockTranscriptDeletedValue)]
+    [JsonSubtypes.KnownSubTypeAttribute(typeof(PageUndeletedWebhookPayload), WebhookEventType.PageUndeletedValue)]
+    [JsonSubtypes.KnownSubTypeAttribute(typeof(PageUnlockedWebhookPayload), WebhookEventType.PageUnlockedValue)]
+    [JsonSubtypes.KnownSubTypeAttribute(typeof(ViewCreatedWebhookPayload), WebhookEventType.ViewCreatedValue)]
+    [JsonSubtypes.KnownSubTypeAttribute(typeof(ViewDeletedWebhookPayload), WebhookEventType.ViewDeletedValue)]
+    [JsonSubtypes.KnownSubTypeAttribute(typeof(ViewUpdatedWebhookPayload), WebhookEventType.ViewUpdatedValue)]
+    [JsonSubtypes.FallBackSubTypeAttribute(typeof(UnknownWebhookPayload))]
+    public abstract class WebhookPayload
+    {
+        /// <summary>
+        /// Unique identifier for this webhook event.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// ISO 8601 timestamp of when the event occurred.
+        /// </summary>
+        [JsonProperty("timestamp")]
+        public string Timestamp { get; set; }
+
+        /// <summary>
+        /// The ID of the workspace where the event originated.
+        /// </summary>
+        [JsonProperty("workspace_id")]
+        public string WorkspaceId { get; set; }
+
+        /// <summary>
+        /// The name of the workspace where the event originated.
+        /// </summary>
+        [JsonProperty("workspace_name")]
+        public string WorkspaceName { get; set; }
+
+        /// <summary>
+        /// The ID of the webhook subscription.
+        /// </summary>
+        [JsonProperty("subscription_id")]
+        public string SubscriptionId { get; set; }
+
+        /// <summary>
+        /// The ID of the integration the subscription is set up with.
+        /// </summary>
+        [JsonProperty("integration_id")]
+        public string IntegrationId { get; set; }
+
+        /// <summary>
+        /// The users or bots that performed the action.
+        /// </summary>
+        [JsonProperty("authors")]
+        public List<WebhookAuthor> Authors { get; set; }
+
+        /// <summary>
+        /// The delivery attempt number (1–8) of the current event delivery.
+        /// </summary>
+        [JsonProperty("attempt_number")]
+        public int AttemptNumber { get; set; }
+
+        /// <summary>
+        /// The Notion API version used to render this webhook event's shape.
+        /// </summary>
+        [JsonProperty("api_version")]
+        public string ApiVersion { get; set; }
+
+        /// <summary>
+        /// The users or bots who own the bot connection and have access to the webhook's entity.
+        /// Only present for public integrations.
+        /// </summary>
+        [JsonProperty("accessible_by")]
+        public List<WebhookAuthor> AccessibleBy { get; set; }
+
+        /// <summary>
+        /// The type of webhook event.
+        /// </summary>
+        [JsonProperty("type")]
+        public virtual WebhookEventType Type { get; set; }
+    }
+}

--- a/Src/Notion.Client/Models/Webhooks/WebhookSchemaUpdatedProperty.cs
+++ b/Src/Notion.Client/Models/Webhooks/WebhookSchemaUpdatedProperty.cs
@@ -1,0 +1,28 @@
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    /// <summary>
+    /// Represents a database property that was created, updated, or deleted in a schema update event.
+    /// </summary>
+    public class WebhookSchemaUpdatedProperty
+    {
+        /// <summary>
+        /// The ID of the database property that changed.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// The name of the database property, or <c>null</c> if deleted.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The action taken on the property. One of "created", "updated", or "deleted".
+        /// </summary>
+        [JsonProperty("action")]
+        public string Action { get; set; }
+    }
+}

--- a/Src/Notion.Client/Models/Webhooks/WebhookUpdatedBlock.cs
+++ b/Src/Notion.Client/Models/Webhooks/WebhookUpdatedBlock.cs
@@ -1,0 +1,22 @@
+using Newtonsoft.Json;
+
+namespace Notion.Client
+{
+    /// <summary>
+    /// Represents a block that was updated in a webhook event.
+    /// </summary>
+    public class WebhookUpdatedBlock
+    {
+        /// <summary>
+        /// The ID of the updated block.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// The type of the updated block. One of "page", "database", or "block".
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+    }
+}

--- a/Src/Notion.Client/Webhooks/NotionWebhookSignature.cs
+++ b/Src/Notion.Client/Webhooks/NotionWebhookSignature.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Notion.Client
+{
+    /// <summary>
+    /// Provides helpers for verifying and generating Notion webhook signatures.
+    /// The signature is sent by Notion in the <c>X-Notion-Signature</c> header and
+    /// follows the format <c>sha256=&lt;64-char-lowercase-hex&gt;</c>.
+    /// </summary>
+    public static class NotionWebhookSignature
+    {
+        private const string SignaturePrefix = "sha256=";
+
+        /// <summary>
+        /// Verifies that the given <paramref name="signature"/> matches the HMAC-SHA256 of
+        /// <paramref name="body"/> keyed with <paramref name="verificationToken"/>.
+        /// Returns <c>false</c> (never throws) for null or malformed input.
+        /// </summary>
+        /// <param name="body">The raw UTF-8 request body string.</param>
+        /// <param name="signature">
+        /// The value of the <c>X-Notion-Signature</c> header, e.g. <c>sha256=abc123…</c>.
+        /// </param>
+        /// <param name="verificationToken">The webhook verification token from Notion.</param>
+        /// <returns><c>true</c> if the signature is valid; otherwise <c>false</c>.</returns>
+        public static Task<bool> VerifySignatureAsync(string body, string signature, string verificationToken)
+        {
+            if (body == null)
+            {
+                return Task.FromResult(false);
+            }
+
+            byte[] bodyBytes;
+            try
+            {
+                bodyBytes = Encoding.UTF8.GetBytes(body);
+            }
+            catch
+            {
+                return Task.FromResult(false);
+            }
+
+            return VerifySignatureAsync(bodyBytes, signature, verificationToken);
+        }
+
+        /// <summary>
+        /// Verifies that the given <paramref name="signature"/> matches the HMAC-SHA256 of
+        /// <paramref name="body"/> keyed with <paramref name="verificationToken"/>.
+        /// Returns <c>false</c> (never throws) for null or malformed input.
+        /// </summary>
+        /// <param name="body">The raw request body bytes.</param>
+        /// <param name="signature">
+        /// The value of the <c>X-Notion-Signature</c> header, e.g. <c>sha256=abc123…</c>.
+        /// </param>
+        /// <param name="verificationToken">The webhook verification token from Notion.</param>
+        /// <returns><c>true</c> if the signature is valid; otherwise <c>false</c>.</returns>
+        public static Task<bool> VerifySignatureAsync(byte[] body, string signature, string verificationToken)
+        {
+            try
+            {
+                if (body == null || string.IsNullOrEmpty(signature) || string.IsNullOrEmpty(verificationToken))
+                {
+                    return Task.FromResult(false);
+                }
+
+                if (!signature.StartsWith(SignaturePrefix, StringComparison.Ordinal))
+                {
+                    return Task.FromResult(false);
+                }
+
+                string providedHex = signature.Substring(SignaturePrefix.Length);
+
+                // A SHA-256 hex digest is always exactly 64 characters.
+                if (providedHex.Length != 64)
+                {
+                    return Task.FromResult(false);
+                }
+
+                string computedHex = ComputeHmacSha256Hex(body, verificationToken);
+                bool valid = ConstantTimeEquals(computedHex, providedHex);
+                return Task.FromResult(valid);
+            }
+            catch
+            {
+                return Task.FromResult(false);
+            }
+        }
+
+        /// <summary>
+        /// Computes the Notion webhook signature for <paramref name="body"/> using
+        /// <paramref name="verificationToken"/>, returning a string of the form
+        /// <c>sha256=&lt;hex&gt;</c>. Useful for testing webhook handlers locally.
+        /// </summary>
+        /// <param name="body">The raw UTF-8 request body string.</param>
+        /// <param name="verificationToken">The webhook verification token from Notion.</param>
+        /// <returns>A signature string of the form <c>sha256=&lt;hex&gt;</c>.</returns>
+        public static Task<string> SignPayloadAsync(string body, string verificationToken)
+        {
+            if (body == null) throw new ArgumentNullException(nameof(body));
+            byte[] bodyBytes = Encoding.UTF8.GetBytes(body);
+            return SignPayloadAsync(bodyBytes, verificationToken);
+        }
+
+        /// <summary>
+        /// Computes the Notion webhook signature for <paramref name="body"/> using
+        /// <paramref name="verificationToken"/>, returning a string of the form
+        /// <c>sha256=&lt;hex&gt;</c>. Useful for testing webhook handlers locally.
+        /// </summary>
+        /// <param name="body">The raw request body bytes.</param>
+        /// <param name="verificationToken">The webhook verification token from Notion.</param>
+        /// <returns>A signature string of the form <c>sha256=&lt;hex&gt;</c>.</returns>
+        public static Task<string> SignPayloadAsync(byte[] body, string verificationToken)
+        {
+            if (body == null) throw new ArgumentNullException(nameof(body));
+            if (string.IsNullOrEmpty(verificationToken)) throw new ArgumentNullException(nameof(verificationToken));
+
+            string hex = ComputeHmacSha256Hex(body, verificationToken);
+            return Task.FromResult(SignaturePrefix + hex);
+        }
+
+        // ── Private helpers ──────────────────────────────────────────────────────
+
+        private static string ComputeHmacSha256Hex(byte[] body, string key)
+        {
+            byte[] keyBytes = Encoding.UTF8.GetBytes(key);
+            using (var hmac = new HMACSHA256(keyBytes))
+            {
+                byte[] hash = hmac.ComputeHash(body);
+                return BytesToHexLower(hash);
+            }
+        }
+
+        private static string BytesToHexLower(byte[] bytes)
+        {
+            var sb = new StringBuilder(bytes.Length * 2);
+            foreach (byte b in bytes)
+            {
+                sb.Append(b.ToString("x2"));
+            }
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Compares two strings in constant time to prevent timing attacks.
+        /// </summary>
+        /// <remarks>
+        /// <c>CryptographicOperations.FixedTimeEquals</c> is not available in
+        /// netstandard2.0, so this method provides an equivalent implementation.
+        /// </remarks>
+        private static bool ConstantTimeEquals(string a, string b)
+        {
+            if (a.Length != b.Length)
+            {
+                return false;
+            }
+
+            int diff = 0;
+            for (int i = 0; i < a.Length; i++)
+            {
+                diff |= a[i] ^ b[i];
+            }
+
+            return diff == 0;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #622, #623, #624.

Brings the .NET SDK to parity with the JS SDK on three missing feature areas:

### Webhook signature verification (#622)
- `NotionWebhookSignature.VerifySignatureAsync(body, signature, verificationToken)` — validates the `X-Notion-Signature` header using HMAC-SHA256
- `NotionWebhookSignature.SignPayloadAsync(body, verificationToken)` — generates a signature for local testing
- Returns `false` (never throws) on malformed input; constant-time comparison to prevent timing attacks
- `string` and `byte[]` overloads for both methods
- netstandard2.0 compatible (manual constant-time compare, no `CryptographicOperations`)

### Webhook event payload types (#623)
- `WebhookPayload` abstract base class with all common fields (`Id`, `Timestamp`, `WorkspaceId`, `Authors`, `AttemptNumber`, `ApiVersion`, etc.)
- `WebhookEventType` extensible enum struct (30 event types)
- 30 strongly-typed concrete payload classes covering all event groups:
  - `comment.*` (created, updated, deleted)
  - `data_source.*` (content_updated, created, deleted, moved, schema_updated, undeleted)
  - `database.*` (content_updated, created, deleted, moved, schema_updated, undeleted)
  - `file_upload.*` (completed, created, expired, upload_failed)
  - `page.*` (content_updated, created, deleted, locked, moved, properties_updated, transcription_block.transcript_deleted, undeleted, unlocked)
  - `view.*` (created, deleted, updated)
- `UnknownWebhookPayload` fallback via `[JsonSubtypes.FallBackSubType]` for forward compatibility
- Supporting types: `WebhookAuthor`, entity classes, `WebhookParentBlock`, `WebhookExternalBlock`, `WebhookUpdatedBlock`, `WebhookSchemaUpdatedProperty`

### Pagination helpers and ID utilities (#624)
- `NotionPaginationHelper.CollectPaginatedAsync<T>(cursor => Task<PaginatedList<T>>)` — auto-fetches all pages into a single `List<T>`
- `NotionIdHelper.ExtractNotionId(urlOrId)` — extracts a UUID from a Notion URL or passes through an existing UUID
- `NotionIdHelper.ExtractPageId` / `ExtractDatabaseId` — convenience wrappers
- `NotionIdHelper.ExtractBlockId` — extracts from `#block-<id>` URL fragments
- netstandard2.0 compatible (no `IAsyncEnumerable`, no `System.Web`)

## Test plan
- [ ] Build passes (0 errors, 0 warnings) ✓
- [ ] Manually verify `NotionWebhookSignature.VerifySignatureAsync` with a known HMAC-SHA256 value
- [ ] Manually verify `NotionIdHelper.ExtractNotionId` with Notion page URLs
- [ ] Verify `NotionPaginationHelper.CollectPaginatedAsync` collects across multiple pages